### PR TITLE
brainstorm/auto: bulk implementation of brainstorm.md

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: e2e
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: cwide-e2e
+      - name: Verify cluster
+        run: kubectl get nodes
+      - name: Run e2e
+        run: bash hack/e2e-test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.23', '1.24']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...
+      - name: Vet
+        run: go vet ./...

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,82 @@
+# brainstorm/auto — autonomous loop over brainstorm.md
+
+This PR is the output of a single autonomous run through the task list in `brainstorm.md`. Every implemented item is one commit; every skipped item is called out below with the reason.
+
+## Summary of what shipped
+
+### Features
+- **Shell completion** (`kubectl cwide completion bash|zsh|fish|powershell`)
+- **`get -c/--columns`** — project a subset of the template's columns without editing it
+- **`get -o json|yaml|csv`** — structured output of rendered rows
+- **`get --sort-by=COL` and `get --filter=COL=val|~regex`** — post-render row transforms; multiple `--filter`s AND together
+- **`tree --max-depth` and cycle detection** — safe rendering when ownerRef graphs loop
+- **`tree --reverse`** — walk ancestors via ownerReferences
+- **New template functions**: `humanBytes`, `age`, `truncate`, `b64dec`, `colorIf`, `safeIndex`
+- **`--no-color`** root flag + `NO_COLOR` env respected
+- **`template lint <file>`** — static validation of column templates
+- **`template scaffold <resource>`** — starter template for a kind
+- **Template inheritance**: `_shared/*.tpl` under template root is prepended to every template
+- **Per-context / per-namespace default template** in `~/.kubectl-cwide/config.yaml`
+- **Alias groups**: `alias set core pod,svc,cm` now works transparently
+- **Cluster-scoped alias sync** via a reserved `__aliases__` key in the templates ConfigMap
+- **Marketplace version pinning**: `install --ref <sha|tag>` writes `~/.kubectl-cwide/marketplace.lock`
+- **Signal handling** at the root so Ctrl-C cancels mid-request cleanly
+
+### Refactors / infra
+- All `context.TODO()` sites now use `cmd.Context()`
+- Client factory construction consolidated in `pkg/clients` (removes 4 copies of the same setup)
+- Native k8s template set curated under `templates/native/`
+- Cookbook (`docs/cookbook.md`) and migration guide (`docs/migration-from-custom-cols.md`)
+
+### CI
+- `test.yml` workflow: Go 1.23/1.24 × linux/mac/windows
+- `e2e.yml` workflow: runs `hack/e2e-test.sh` against a kind cluster on every PR
+
+### Test coverage
+- `pkg/parser/funcs/builtins_test.go` — HumanBytes, Truncate, B64Dec, ColorIf, SafeIndex
+- `pkg/cmd/marketplace/lock_test.go` — LockFile upsert semantics
+- `pkg/cmd/template/lint_test.go` (added by hook — sanity checks lint output)
+
+### Housekeeping
+- README typo fix (`kubectl-ciwe` → `kubectl-cwide`)
+- Removed the previously-shipped `list all` command (already gone on `main` — pre-loop cleanup)
+
+## Skipped (with reasons)
+
+| # | Item | Why skipped |
+|---|------|-------------|
+| 22 | Marketplace signed templates | Needs real cosign/sigstore infra (KMS keys, transparency log, published signatures) — not viable from sandbox; needs owner decision on trust model |
+| 23 | Marketplace private registries (OCI/S3/GitLab) | Each source needs its own client + auth + end-to-end tests; needs prioritization decision first |
+| 24 | Marketplace publish command | Needs a real community index repo to PR against; no such repo exists yet (marketplace is index-in-source) |
+| 25 | Interactive TUI (Bubbletea) | Project-scale work (list views, focus, fuzzy search, live data binding, tests); can't be honestly done in one loop iteration |
+| 26 | `diff` command | Useful diff needs either live cluster + last-applied-configuration annotation, or git history, or explicit --from/--to — each a different feature |
+| 27 | `get all-resources` partial-failure | Already correct — audited in-place, no code change needed |
+| 28 | Discovery cache | `factory.ToDiscoveryClient()` is already a CachedDiscoveryClient (~/.kube/cache/discovery); no work to do |
+| 29 | `template edit` race protection | File lock via os.O_EXCL solves single-host only; multi-host is the real failure mode. Needs design discussion |
+| 30 | -A audit | Already consistent — audited, no change needed |
+| 31 | Windows path handling | Audited — all filesystem paths use filepath.Join; only unrelated `/` uses are URL/GVK strings. Full support needs CI matrix (#36) to verify |
+| 35 | Drop vendor dir | Affects offline builds and CI; policy call, not mechanical |
+| 39 | Verify goreleaser + krew index | Needs live GitHub Actions observation for v0.7.0 — can't do from sandbox |
+| 42 | Restructure README into `docs/` | Would break existing anchor links and reorganize content krew references. Individual doc pages added under `docs/` instead |
+
+## Not covered (was implemented pre-loop or by hook)
+- **Watch mode** — already present in `pkg/cmd/get/get.go` (`--watch`/`-w`)
+- **Tree custom edge types** — already supported via `--rules` YAML
+
+## Testing
+- All existing tests pass: `go test ./...`
+- New tests added (see above)
+- CI matrix will exercise on Go 1.23/1.24 × linux/mac/windows once merged
+
+## How to open
+
+Because this sandbox can't reach github.com, please run manually:
+
+```sh
+gh pr create --repo reborn1867/kubectl-cwide \
+  --base main --head brainstorm/auto \
+  --title "brainstorm/auto: bulk implementation of brainstorm.md" \
+  --body-file PR_BODY.md
+```
+
+or open through the GitHub web UI.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Managing Kubernetes resources often requires printing extra columns for specific
 - **Custom Resource Aliases**: Define short aliases for long resource type names (e.g. `vw` for `validatingwebhookconfigurations`) with automatic resolution in `get` and `tree` commands.
 
 ## Installation
-As a [krew](https://github.com/kubernetes-sigs/krew) plugin, `kubectl-ciwe` can be installed with a simple command as following once it's officially accepted.
+As a [krew](https://github.com/kubernetes-sigs/krew) plugin, `kubectl-cwide` can be installed with a simple command as following once it's officially accepted.
 ```
 kubectl krew install cwide
 ```

--- a/brainstorm.md
+++ b/brainstorm.md
@@ -1,0 +1,65 @@
+# kubectl-cwide — Brainstorm
+
+A working list of ideas and known rough edges. Nothing here is committed to; use it as a menu.
+
+## Features
+
+### Templating
+- **Watch mode for `get`** — `-w/--watch` that re-renders the custom template as the informer stream fires, similar to `kubectl get -w`. Would need incremental row updates rather than full redraw.
+- **JSON/YAML/CSV output** — `-o json|yaml|csv` after template evaluation so users can pipe cwide-computed columns into `jq`, spreadsheets, or dashboards without re-implementing the JSONPath expressions.
+- **Sort/filter flags** — `--sort-by=<column>` and `--filter='column=value'` operating on rendered rows, so users don't need to write awk/grep pipelines.
+- **Column selection at call time** — `-c NAME,STATUS,AGE` to project a subset of columns from a template without editing the file.
+- **Template inheritance / includes** — `{{ include "common.podHealth" . }}` across templates so shared snippets aren't duplicated in every resource file. Right now `text/template` `define` only works within a single file.
+- **Template validation** — `kubectl cwide template lint <file>` that checks JSONPath expressions against the resource's OpenAPI schema and reports unknown fields before runtime.
+- **Namespaced defaults** — per-namespace or per-context default template selection, driven by `~/.kubectl-cwide/config.yaml` (right now `default.tpl` is global).
+- **More built-in template functions** — `humanBytes`, `age` (already-formatted duration), `colorIf`, `truncate`, `json`, `b64dec` for secrets. `probeCheck` proves the pattern works; extend it.
+- **Colorized output** — ANSI colors bound to condition/status columns (Ready green, NotReady red, Pending yellow), with `--no-color` and `NO_COLOR` env var support.
+
+### Marketplace / sharing
+- **Template versioning** — pin a marketplace template to a version and record it in `~/.kubectl-cwide/config.yaml` so `sync` won't silently upgrade.
+- **Signed templates** — cosign/sigstore signatures on marketplace entries; `marketplace install` verifies before writing to disk.
+- **Private registries** — allow non-GitHub sources (OCI registries via ORAS, S3 buckets, GitLab). The marketplace API today assumes GitHub.
+- **`marketplace publish`** — one-command flow to open a PR against the community index repo from a local template directory.
+
+### Discovery & UX
+- **Interactive TUI** — `kubectl cwide tui` with fuzzy resource search, live-rendered custom columns, and drill-down into `tree`. Bubbletea-based.
+- **Shell completion** — `completion bash|zsh|fish|powershell` producing scripts that complete resource kinds, template names, aliases, and marketplace entries.
+- **`explain` integration** — `kubectl cwide template scaffold <resource>` that reads `kubectl explain --recursive` and pre-populates a template with every leaf field commented out, so users can uncomment what they want.
+- **`diff` command** — `kubectl cwide diff <resource>` comparing two revisions of the same object (via `resourceVersion` history from audit log or `kubectl.kubernetes.io/last-applied-configuration`) using the current template columns.
+
+### Tree
+- **Cyclic reference detection** — protect the tree walk from ownerRef loops (rare, but happens with broken controllers) with a visited set + `--max-depth`.
+- **Custom edge types** — user-defined "follow this label to that kind" edges in a config file, extending the built-in owner/selector/field rules.
+- **`--reverse`** — show ancestors of a resource, not just descendants.
+
+### Aliases
+- **Alias groups** — `kubectl cwide alias set core "pod,svc,deploy,cm"` for one-shot multi-kind gets.
+- **Cluster-scoped aliases via ConfigMap** — same sync mechanism as templates so a team can share `vw` and friends.
+
+## Bug fixes / hardening
+
+- **`context.TODO()` everywhere** — `pkg/cmd/configmap/push.go`, `pkg/cmd/configmap/sync.go`, `pkg/cmd/initialization/init.go`. Thread `cmd.Context()` through so callers can cancel and set timeouts (relevant for `sync` in CI).
+- **`get all-resources` failure modes** — one failing API group currently can taint the whole listing (or not, depending on error handling). Audit: partial results should print with a warning, not abort.
+- **Discovery cache** — `init` and `get all-resources` re-hit the discovery endpoint on every invocation. Reuse `~/.kube/cache/discovery` like kubectl does.
+- **Template edit race** — `template edit` opens `$EDITOR` and rewrites the file on save. If the user edits while `configmap sync` runs, one silently overwrites the other. Add an fs lock or at least a mtime check on save.
+- **Krew manifest name typo** — README line 24 says `kubectl-ciwe` (should be `cwide`). Small, but the code block is what users copy.
+- **`get -A` semantics** — verify all-namespaces flag is plumbed through consistently across `get`, `tree`, and `get all-resources`.
+- **Nil-pointer risk in JSONPath filters** — expressions like `.status.containerStatuses[0].restartCount` panic-adjacent when `containerStatuses` is empty (pending pod). Add a safe-navigation helper `{{ safeIndex . "status" "containerStatuses" 0 "restartCount" }}` and document it as the recommended pattern.
+- **Windows path handling** — template paths are joined with `/` in a few places. Sanity-check on Windows or drop it from the support matrix explicitly.
+- **`--kubeconfig` at persistent-flag level but not always read** — some subcommands construct their own client factory and ignore the flag. Route everything through a shared `genericclioptions.ConfigFlags`.
+- **Test coverage gaps** — `pkg/cmd/configmap/`, `pkg/cmd/marketplace/`, and `pkg/cmd/template/edit.go` have no `_test.go`. `get`, `tree`, `list`, `alias` do. Marketplace especially needs mocked HTTP tests.
+- **Goreleaser + krew index** — verify the release just cut (v0.7.0) actually reaches the krew index; the previous automation PRs (#4, #5, #7) suggest this has been flaky.
+
+## Refactors / infra
+
+- **Adopt `cmd.Context()`** — see above; also lets us wire up signal handling once at root and get Ctrl-C mid-render for free.
+- **Extract `client-go` factory** — every command re-constructs REST config, discovery client, dynamic client. One `pkg/clients` package would remove ~200 lines of duplication.
+- **Vendor dir vs go modules** — repo vendors deps *and* has `go.sum`. Pick one. Vendoring made sense pre-modules; today it doubles review noise on dep bumps.
+- **CI matrix** — GitHub Actions currently (check `.github/`) may only run one Go version / OS. Add 1.22 + 1.23 × linux/mac/windows.
+- **E2E harness** — `15a05d7` added e2e tests. Wire them into CI against a kind cluster on PRs, not just locally.
+
+## Docs
+
+- **Cookbook page** — one-liners for common asks: "show pod restart reason", "show pvc bound-to node", "show hpa current vs desired". Each with the template file that produces it.
+- **Migration guide from `kubectl-custom-cols`** — the project cwide was inspired by. Show side-by-side syntax so users can move.
+- **`README` restructure** — README is currently ~450 lines linear. Split into `docs/` with Getting Started, Templates, Marketplace, Tree, Aliases, and Reference sections.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
@@ -9,9 +12,12 @@ import (
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	streams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	root := cmd.NewCmdCwide(streams)
-	if err := root.Execute(); err != nil {
+	if err := root.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,133 @@
+# Cookbook
+
+Short recipes for common template patterns. Each recipe shows the template file and the resulting `kubectl cwide get` output.
+
+## Pod restart reason
+
+Show why containers restarted — surface `lastState.terminated.reason` alongside restart count.
+
+`~/.kubectl-cwide/templates/pod--v1/restart-reason.tpl`:
+
+```
+NAME             RESTARTS         LAST_REASON                                                          LAST_EXIT
+.metadata.name   .status.containerStatuses[0].restartCount   .status.containerStatuses[0].lastState.terminated.reason   .status.containerStatuses[0].lastState.terminated.exitCode
+```
+
+Run:
+```sh
+kubectl cwide get pod --template restart-reason
+```
+
+## PVC bound-to node
+
+Trace a PVC through its bound PV to the node currently hosting it.
+
+`~/.kubectl-cwide/templates/persistentvolumeclaim--v1/bound-node.tpl`:
+
+```
+NAME             STATUS               STORAGE                                            VOLUME               NODE
+.metadata.name   .status.phase        .spec.resources.requests.storage                   .spec.volumeName     {{ template "PVCNode" . }}
+
+{{- define "PVCNode" -}}
+{{- $pv := lookup "v1" "PersistentVolume" "" .spec.volumeName -}}
+{{- if $pv -}}
+  {{- if $pv.spec.nodeAffinity -}}
+    {{- range $pv.spec.nodeAffinity.required.nodeSelectorTerms -}}
+      {{- range .matchExpressions -}}
+        {{- if eq .key "kubernetes.io/hostname" -}}{{- index .values 0 -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+```
+
+## HPA current vs desired
+
+At-a-glance capacity signal.
+
+`~/.kubectl-cwide/templates/horizontalpodautoscaler-autoscaling-v2/desired.tpl`:
+
+```
+NAME             MIN                        MAX                        CURRENT                     DESIRED
+.metadata.name   .spec.minReplicas          .spec.maxReplicas          .status.currentReplicas     .status.desiredReplicas
+```
+
+## Deployment rollout at a glance
+
+Ready vs updated vs available.
+
+`~/.kubectl-cwide/templates/deployment-apps-v1/rollout.tpl`:
+
+```
+NAME             READY                      UPDATED                       AVAILABLE                 UNAVAILABLE
+.metadata.name   .status.readyReplicas      .status.updatedReplicas       .status.availableReplicas .status.unavailableReplicas
+```
+
+## Node pressure
+
+Which nodes are under memory / disk pressure right now.
+
+`~/.kubectl-cwide/templates/node--v1/pressure.tpl`:
+
+```
+NAME             READY                                                                                          MEM_PRESSURE                                                                                DISK_PRESSURE                                                                                     PID_PRESSURE
+.metadata.name   .status.conditions[?(@.type=="Ready")].status   .status.conditions[?(@.type=="MemoryPressure")].status   .status.conditions[?(@.type=="DiskPressure")].status   .status.conditions[?(@.type=="PIDPressure")].status
+```
+
+## Ingress backend routes
+
+Show all `host → path → service:port` rows a single Ingress serves.
+
+`~/.kubectl-cwide/templates/ingress-networking.k8s.io-v1/routes.tpl`:
+
+```
+NAME             HOST                            PATH                                    SERVICE                                              PORT
+.metadata.name   .spec.rules[0].host             .spec.rules[0].http.paths[0].path       .spec.rules[0].http.paths[0].backend.service.name    .spec.rules[0].http.paths[0].backend.service.port.number
+```
+
+Note: this only shows the first rule/path. For fully expanded routing, use `text/template` with `range` over `.spec.rules`.
+
+## Secret age & keys
+
+Names of the keys stored in each Secret plus how old it is.
+
+`~/.kubectl-cwide/templates/secret--v1/keys.tpl`:
+
+```
+NAME             TYPE                        KEYS                                                          AGE
+.metadata.name   .type                       {{ range $k, $_ := .data }}{{$k}} {{ end }}                   .metadata.creationTimestamp
+```
+
+## Service to endpoints
+
+Which service targets which pod IPs. Great for debugging "why is nothing responding on my Service?".
+
+`~/.kubectl-cwide/templates/service--v1/endpoints.tpl`:
+
+```
+NAME             TYPE                                CLUSTERIP                     PORTS                                              SELECTOR
+.metadata.name   .spec.type                          .spec.clusterIP               .spec.ports[0].port                                {{ range $k, $v := .spec.selector }}{{$k}}={{$v}} {{ end }}
+```
+
+## Job success/failure
+
+Job progress across attempts.
+
+`~/.kubectl-cwide/templates/job-batch-v1/attempts.tpl`:
+
+```
+NAME             COMPLETIONS                                     SUCCEEDED                     FAILED                     ACTIVE                          START
+.metadata.name   .status.succeeded/.spec.completions             .status.succeeded             .status.failed             .status.active                  .status.startTime
+```
+
+---
+
+### Contributing recipes
+
+Have a template you use daily? Add it here in the same format:
+1. One sentence describing what it shows.
+2. Path & filename.
+3. Template body in a code block.
+
+Then open a PR.

--- a/docs/migration-from-custom-cols.md
+++ b/docs/migration-from-custom-cols.md
@@ -1,0 +1,80 @@
+# Migrating from kubectl-custom-cols
+
+`kubectl-cwide` was inspired by [kubectl-custom-cols](https://github.com/webofmars/kubectl-custom-cols). If you're already using custom-cols, migration is straightforward — the JSONPath expressions carry over verbatim; only the surrounding structure changes.
+
+## Concept mapping
+
+| kubectl-custom-cols                       | kubectl-cwide                                              |
+|-------------------------------------------|------------------------------------------------------------|
+| One template file per resource            | Directory per resource; multiple named templates each      |
+| Two lines: header + JSONPath              | Same (`.tpl`) or structured YAML (`.yaml`)                 |
+| Called via `kubectl custom-cols <kind>`   | Called via `kubectl cwide get <kind>`                      |
+| Global template dir                       | `--template-path` flag, or `~/.kubectl-cwide/config.yaml`  |
+| Plain JSONPath only                       | JSONPath + `text/template` + Helm-style helpers            |
+| No sharing                                | ConfigMap sync + Marketplace                               |
+
+## Side-by-side syntax
+
+### Pod overview
+
+**custom-cols** (`~/.custom-cols/pod`):
+```
+NAME     STATUS         AGE
+.metadata.name   .status.phase   .metadata.creationTimestamp
+```
+
+**cwide** (`~/.kubectl-cwide/templates/pod--v1/default.tpl`):
+```
+NAME     STATUS         AGE
+.metadata.name   .status.phase   .metadata.creationTimestamp
+```
+
+Identical body — just the location changes. In cwide, `pod--v1` is `<resource>-<group>-<version>` where the empty group leaves a doubled dash.
+
+### Selecting a template variant
+
+**custom-cols** — one template per kind; no variants.
+
+**cwide** — multiple named templates per kind:
+```sh
+kubectl cwide get pod --template debug
+kubectl cwide get pod --template original-output
+```
+
+## Migration steps
+
+1. **Copy your existing files** into the cwide layout:
+   ```sh
+   mkdir -p ~/.kubectl-cwide/templates/pod--v1
+   cp ~/.custom-cols/pod ~/.kubectl-cwide/templates/pod--v1/default.tpl
+   ```
+   Repeat for each kind. The rule for the directory name is `<plural>-<group>-<version>` (built-ins have an empty group — hence `pod--v1`, `service--v1`, `configmap--v1`, `deployment-apps-v1`, `job-batch-v1`, etc.).
+
+2. **Init to fill in the rest**. Once you've copied your bespoke templates, run:
+   ```sh
+   kubectl cwide init
+   ```
+   to auto-generate defaults for every other resource the cluster serves. Your copied files are preserved.
+
+3. **Point your muscle memory**. Replace any `alias` for `kubectl custom-cols` with:
+   ```sh
+   alias k='kubectl cwide get'
+   ```
+
+## Features you gain by moving
+
+- **Named variants** — `pod/default.tpl` and `pod/debug.tpl` coexist; pick with `--template`.
+- **Text templates + JSONPath together** — call `{{ template "PodReady" . }}` from within a `.tpl` line.
+- **Team sharing** — push templates into a ConfigMap so the whole cluster gets the same output shape.
+- **Marketplace** — browse and install community-shared templates.
+- **Aliases** — `kubectl cwide alias set vw validatingwebhookconfigurations`, then `kubectl cwide get vw` works everywhere.
+- **Tree view** — `kubectl cwide tree deploy/my-app` walks ownerRefs, label selectors, and field refs.
+
+## What doesn't carry over
+
+- **Global vs per-kind config format** — custom-cols reads one file per kind; cwide reads a directory. There's no drop-in "flat file" mode.
+- **Command name** — `custom-cols` becomes `cwide get`. If you have shell aliases or scripts, update them.
+
+## Getting help
+
+Open an issue at https://github.com/reborn1867/kubectl-cwide/issues if a migration edge case bites you — we'll add it to this page.

--- a/pkg/clients/factory.go
+++ b/pkg/clients/factory.go
@@ -1,0 +1,33 @@
+package clients
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/utils/ptr"
+)
+
+// FactoryFromCmd builds a cmdutil.Factory using the standard kubeconfig
+// discovery, honoring --kubeconfig and --context flags from the given cobra
+// command (both optional).
+//
+// This is the single place cwide constructs Kubernetes client factories so all
+// subcommands share the same discovery cache and TLS/QPS settings.
+func FactoryFromCmd(cmd *cobra.Command, kubeContext string) cmdutil.Factory {
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
+		WithDeprecatedPasswordFlag().
+		WithDiscoveryBurst(300).
+		WithDiscoveryQPS(50.0)
+
+	if cmd != nil {
+		if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
+			kubeConfigFlags.KubeConfig = ptr.To(v.Value.String())
+		}
+	}
+	if kubeContext != "" {
+		kubeConfigFlags.Context = &kubeContext
+	}
+
+	matchVersionFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	return cmdutil.NewFactory(matchVersionFlags)
+}

--- a/pkg/cmd/alias/set.go
+++ b/pkg/cmd/alias/set.go
@@ -20,16 +20,24 @@ func NewCmdAliasSet() *cobra.Command {
 		Short: "Create or update a resource type alias",
 		Long: `Set a custom alias for a Kubernetes resource type.
 
+The RESOURCE argument may be a single resource type or a comma-separated list
+(an "alias group") — e.g. "pod,service,configmap". Comma-separated targets pass
+through to the resource builder unchanged, so 'kubectl cwide get <alias>' lists
+all of them at once.
+
 The alias is checked for conflicts against:
   - Existing aliases in the config
   - Built-in Kubernetes resource short names (via Discovery API)
 
 A warning is printed if the alias conflicts with an existing name, but the
 alias is still saved.`,
-		Example: `  # Set 'pd' as an alias for 'pods'
+		Example: `  # Single-resource alias
   kubectl cwide alias set pd pods
 
-  # Set 'vw' as an alias for 'validatingwebhookconfigurations'
+  # Alias group: 'core' lists pods, services, and configmaps together
+  kubectl cwide alias set core pod,service,configmap
+
+  # Long name → short alias
   kubectl cwide alias set vw validatingwebhookconfigurations`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/alias/set.go
+++ b/pkg/cmd/alias/set.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubectl-cwide/pkg/clients"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/utils/ptr"
 )
 
 func NewCmdAliasSet() *cobra.Command {
@@ -93,20 +91,7 @@ type shortNameConflict struct {
 }
 
 func checkK8sShortNameConflicts(cmd *cobra.Command, context, alias string) []shortNameConflict {
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
-		WithDeprecatedPasswordFlag().
-		WithDiscoveryBurst(300).
-		WithDiscoveryQPS(50.0)
-
-	if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
-		kubeConfigFlags.KubeConfig = ptr.To(v.Value.String())
-	}
-	if context != "" {
-		kubeConfigFlags.Context = &context
-	}
-
-	matchVersionFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	factory := cmdutil.NewFactory(matchVersionFlags)
+	factory := clients.FactoryFromCmd(cmd, context)
 
 	discoveryClient, err := factory.ToDiscoveryClient()
 	if err != nil {

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,0 +1,51 @@
+package completion
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdCompletion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "completion [bash|zsh|fish|powershell]",
+		Short:                 "Generate shell completion scripts",
+		Long:                  completionLong,
+		Example:               completionExample,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(c *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return c.Root().GenBashCompletionV2(os.Stdout, true)
+			case "zsh":
+				return c.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return c.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return c.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+const completionLong = `Output shell completion code for the specified shell (bash, zsh, fish, or powershell).
+The script must be sourced to enable interactive completion of commands, flags, and arguments.`
+
+const completionExample = `  # Load completion for the current bash session
+  source <(kubectl cwide completion bash)
+
+  # Persist bash completion (Linux)
+  kubectl cwide completion bash > /etc/bash_completion.d/kubectl-cwide
+
+  # Load completion for the current zsh session
+  source <(kubectl cwide completion zsh)
+
+  # Persist fish completion
+  kubectl cwide completion fish > ~/.config/fish/completions/kubectl-cwide.fish
+
+  # Save powershell completion
+  kubectl cwide completion powershell > kubectl-cwide.ps1`

--- a/pkg/cmd/configmap/push.go
+++ b/pkg/cmd/configmap/push.go
@@ -1,7 +1,6 @@
 package configmap
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,6 +39,7 @@ only templates for a specific resource type.`,
   # Push to a specific ConfigMap
   kubectl cwide configmap push --name my-templates --cm-namespace default`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			cmName := cmd.Flag("name").Value.String()
 			cmNamespace := cmd.Flag("cm-namespace").Value.String()
 
@@ -96,7 +96,7 @@ only templates for a specific resource type.`,
 
 			cmClient := clientset.CoreV1().ConfigMaps(cmNamespace)
 
-			existing, err := cmClient.Get(context.TODO(), cmName, metav1.GetOptions{})
+			existing, err := cmClient.Get(ctx, cmName, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				// Create the ConfigMap
 				cm := &corev1.ConfigMap{
@@ -106,7 +106,7 @@ only templates for a specific resource type.`,
 					},
 					Data: data,
 				}
-				if _, err := cmClient.Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
+				if _, err := cmClient.Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 					return fmt.Errorf("failed to create ConfigMap: %w", err)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "Created ConfigMap %s/%s with %d template(s).\n", cmNamespace, cmName, len(data))
@@ -122,7 +122,7 @@ only templates for a specific resource type.`,
 			for k, v := range data {
 				existing.Data[k] = v
 			}
-			if _, err := cmClient.Update(context.TODO(), existing, metav1.UpdateOptions{}); err != nil {
+			if _, err := cmClient.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
 				return fmt.Errorf("failed to update ConfigMap: %w", err)
 			}
 

--- a/pkg/cmd/configmap/push.go
+++ b/pkg/cmd/configmap/push.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -15,8 +16,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// aliasesConfigMapKey is the data-map key used to store a YAML-marshalled
+// alias map (name → target) so aliases can be shared across a team via the
+// same ConfigMap that carries templates.
+const aliasesConfigMapKey = "__aliases__"
+
 func NewCmdPush() *cobra.Command {
 	var resource string
+	var includeAliases bool
 
 	pushCMD := &cobra.Command{
 		Use:        "push",
@@ -77,6 +84,15 @@ only templates for a specific resource type.`,
 				data[key] = string(content)
 			}
 
+			if includeAliases {
+				cfg, err := utils.LoadConfig()
+				if err == nil && len(cfg.Aliases) > 0 {
+					if raw, err := yaml.Marshal(cfg.Aliases); err == nil {
+						data[aliasesConfigMapKey] = string(raw)
+					}
+				}
+			}
+
 			if len(data) == 0 {
 				if resource != "" {
 					return fmt.Errorf("no templates found for resource type %q", resource)
@@ -132,6 +148,7 @@ only templates for a specific resource type.`,
 	}
 
 	pushCMD.Flags().StringVarP(&resource, "resource", "r", "", "Only push templates for this resource type (e.g. pod, deployment)")
+	pushCMD.Flags().BoolVar(&includeAliases, "with-aliases", false, "Also push resource aliases from local config under the reserved key "+aliasesConfigMapKey)
 
 	return pushCMD
 }

--- a/pkg/cmd/configmap/sync.go
+++ b/pkg/cmd/configmap/sync.go
@@ -1,7 +1,6 @@
 package configmap
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +41,7 @@ Use --force to always overwrite regardless of priority.`,
   # Force overwrite all local templates
   kubectl cwide configmap sync --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			cmName := cmd.Flag("name").Value.String()
 			cmNamespace := cmd.Flag("cm-namespace").Value.String()
 
@@ -60,7 +60,7 @@ Use --force to always overwrite regardless of priority.`,
 				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 
-			cm, err := clientset.CoreV1().ConfigMaps(cmNamespace).Get(context.TODO(), cmName, metav1.GetOptions{})
+			cm, err := clientset.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get ConfigMap %s/%s: %w", cmNamespace, cmName, err)
 			}

--- a/pkg/cmd/configmap/sync.go
+++ b/pkg/cmd/configmap/sync.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -75,7 +76,17 @@ Use --force to always overwrite regardless of priority.`,
 
 			synced := 0
 			skipped := 0
+			aliasesSynced := 0
 			for key, value := range cm.Data {
+				if key == aliasesConfigMapKey {
+					n, err := mergeRemoteAliases([]byte(value), force)
+					if err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Skipping %s: %v\n", key, err)
+						continue
+					}
+					aliasesSynced = n
+					continue
+				}
 				parts := strings.SplitN(key, "..", 2)
 				if len(parts) != 2 {
 					fmt.Fprintf(cmd.ErrOrStderr(), "Skipping invalid key %q (expected <resource-dir>..<template-name>)\n", key)
@@ -103,6 +114,9 @@ Use --force to always overwrite regardless of priority.`,
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Synced %d template(s), skipped %d.\n", synced, skipped)
+			if aliasesSynced > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Merged %d alias(es) from ConfigMap.\n", aliasesSynced)
+			}
 			return nil
 		},
 	}
@@ -129,6 +143,42 @@ func shouldOverwrite(sources []string, localExists bool, force bool) bool {
 		}
 	}
 	return false
+}
+
+// mergeRemoteAliases merges a YAML alias map (name → target) from the
+// ConfigMap into the local config. Existing local aliases are preserved
+// unless `force` is true, in which case remote wins.
+// Returns the number of aliases added or updated.
+func mergeRemoteAliases(raw []byte, force bool) (int, error) {
+	remote := map[string]string{}
+	if err := yaml.Unmarshal(raw, &remote); err != nil {
+		return 0, fmt.Errorf("parse aliases yaml: %w", err)
+	}
+	if len(remote) == 0 {
+		return 0, nil
+	}
+	cfg, err := utils.LoadConfig()
+	if err != nil {
+		return 0, fmt.Errorf("load config: %w", err)
+	}
+	if cfg.Aliases == nil {
+		cfg.Aliases = map[string]string{}
+	}
+	n := 0
+	for name, target := range remote {
+		if _, exists := cfg.Aliases[name]; exists && !force {
+			continue
+		}
+		cfg.Aliases[name] = target
+		n++
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	if err := utils.SaveConfig(cfg); err != nil {
+		return 0, fmt.Errorf("save config: %w", err)
+	}
+	return n, nil
 }
 
 // loadTemplateSources reads the templateSources from the config file.

--- a/pkg/cmd/get/all_resources.go
+++ b/pkg/cmd/get/all_resources.go
@@ -12,13 +12,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/utils/ptr"
+
+	"github.com/kubectl-cwide/pkg/clients"
 )
 
 const (
@@ -117,23 +117,7 @@ The output is a single table sorted by APIVERSION, KIND, NAMESPACE, NAME.`,
 }
 
 func (o *AllResourcesOptions) Complete(cmd *cobra.Command) error {
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
-		WithDeprecatedPasswordFlag().
-		WithDiscoveryBurst(300).
-		WithDiscoveryQPS(50.0)
-
-	if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
-		kubeConfigFlags.KubeConfig = ptr.To(v.Value.String())
-	}
-	if o.Context != "" {
-		kubeConfigFlags.Context = &o.Context
-	}
-	if o.Namespace != "" && !o.AllNamespaces {
-		kubeConfigFlags.Namespace = ptr.To(o.Namespace)
-	}
-
-	matchVersionFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	o.factory = cmdutil.NewFactory(matchVersionFlags)
+	o.factory = clients.FactoryFromCmd(cmd, o.Context)
 
 	if o.Namespace == "" && !o.AllNamespaces {
 		ns, _, err := o.factory.ToRawKubeConfigLoader().Namespace()

--- a/pkg/cmd/get/customcolumn.go
+++ b/pkg/cmd/get/customcolumn.go
@@ -275,6 +275,9 @@ type CustomColumnsPrinter struct {
 	*utils.DefaultTableGenerator
 	Headers     []string // - Headers is used to store the headers for the custom columns
 	CustomTable table.Writer
+	// RowSink, when non-nil, captures each row's column values instead of
+	// writing them to the tabwriter. Used by structured output formats.
+	RowSink func(cols []string)
 }
 
 // SelectColumns filters the printer's Columns/Headers to the named subset,
@@ -339,7 +342,7 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 		defer w.Flush()
 	}
 
-	if s.CustomTable == nil {
+	if s.CustomTable == nil && s.RowSink == nil {
 		t := reflect.TypeOf(obj)
 		if !s.NoHeaders && t != s.lastType {
 			headers := make([]string, len(s.Columns))
@@ -453,7 +456,9 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []pars
 		multiLinesColumns = append(multiLinesColumns, lines)
 	}
 
-	if s.CustomTable != nil {
+	if s.RowSink != nil {
+		s.RowSink(append([]string(nil), columns...))
+	} else if s.CustomTable != nil {
 		var row table.Row
 		for idx := range columns {
 			row = append(row, columns[idx])

--- a/pkg/cmd/get/customcolumn.go
+++ b/pkg/cmd/get/customcolumn.go
@@ -277,6 +277,42 @@ type CustomColumnsPrinter struct {
 	CustomTable table.Writer
 }
 
+// SelectColumns filters the printer's Columns/Headers to the named subset,
+// preserving the order given in `names`. Names are matched case-insensitively
+// against Column.Header. Unknown names are reported as an error.
+func (s *CustomColumnsPrinter) SelectColumns(names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	byHeader := make(map[string]Column, len(s.Columns))
+	for _, c := range s.Columns {
+		byHeader[strings.ToUpper(c.Header)] = c
+	}
+	newCols := make([]Column, 0, len(names))
+	newHeaders := make([]string, 0, len(names))
+	var missing []string
+	for _, n := range names {
+		key := strings.ToUpper(strings.TrimSpace(n))
+		c, ok := byHeader[key]
+		if !ok {
+			missing = append(missing, n)
+			continue
+		}
+		newCols = append(newCols, c)
+		newHeaders = append(newHeaders, c.Header)
+	}
+	if len(missing) > 0 {
+		available := make([]string, 0, len(s.Columns))
+		for _, c := range s.Columns {
+			available = append(available, c.Header)
+		}
+		return fmt.Errorf("unknown column(s) %v; available: %v", missing, available)
+	}
+	s.Columns = newCols
+	s.Headers = newHeaders
+	return nil
+}
+
 func (s *CustomColumnsPrinter) WithCustomTable() *CustomColumnsPrinter {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
@@ -74,24 +75,74 @@ func NewGetOptions(streams genericiooptions.IOStreams) *GetOptions {
 }
 
 // resolveTemplatePrinter finds the template file (.yaml first, then .tpl) and creates the appropriate printer.
+// Shared helpers under <rootPath>/_shared/*.tpl are concatenated at the top of .tpl template bodies before parsing,
+// and merged into the `helpers` field of .yaml templates.
 func resolveTemplatePrinter(rootPath, crdTemplateDir, templateName string, decoder runtime.Decoder, restConfig *rest.Config) (*CustomColumnsPrinter, error) {
 	dir := filepath.Join(rootPath, crdTemplateDir)
+	sharedHelpers, _ := loadSharedHelpers(rootPath)
 
 	// Try .yaml first
 	yamlPath := filepath.Join(dir, templateName+".yaml")
 	if data, err := os.ReadFile(yamlPath); err == nil {
+		if sharedHelpers != "" {
+			data = injectYAMLHelpers(data, sharedHelpers)
+		}
 		return NewCustomColumnsPrinterFromYAML(data, decoder, restConfig)
 	}
 
 	// Fall back to .tpl
 	tplPath := filepath.Join(dir, templateName+".tpl")
-	file, err := os.Open(tplPath)
+	data, err := os.ReadFile(tplPath)
 	if err != nil {
 		return nil, fmt.Errorf("template not found (tried %s.yaml and %s.tpl in %s)", templateName, templateName, dir)
 	}
-	defer file.Close()
 
-	return NewCustomColumnsPrinterFromTemplate(file, decoder, restConfig)
+	if sharedHelpers != "" {
+		data = append([]byte(sharedHelpers+"\n"), data...)
+	}
+	return NewCustomColumnsPrinterFromTemplate(strings.NewReader(string(data)), decoder, restConfig)
+}
+
+// loadSharedHelpers concatenates every *.tpl file under <rootPath>/_shared/
+// so `{{ template "name" . }}` calls from templates can resolve helpers
+// defined once and reused everywhere.
+func loadSharedHelpers(rootPath string) (string, error) {
+	sharedDir := filepath.Join(rootPath, "_shared")
+	entries, err := os.ReadDir(sharedDir)
+	if err != nil {
+		return "", err // no shared/ dir is fine, caller ignores the error
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(e.Name(), ".tpl") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sharedDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		b.Write(data)
+		b.WriteString("\n")
+	}
+	return b.String(), nil
+}
+
+// injectYAMLHelpers appends sharedHelpers to the YAML template's `helpers`
+// field. If the field does not exist, it's created.
+func injectYAMLHelpers(data []byte, sharedHelpers string) []byte {
+	// Cheap textual merge: if the file already has a `helpers: |` block,
+	// leave that alone (the YAML parser can only handle one). Otherwise
+	// prepend a new one.
+	if strings.Contains(string(data), "\nhelpers:") || strings.HasPrefix(string(data), "helpers:") {
+		return data
+	}
+	// indent each helper line by 2 spaces for the block scalar
+	indented := "  " + strings.ReplaceAll(sharedHelpers, "\n", "\n  ")
+	block := "helpers: |\n" + indented + "\n"
+	return append([]byte(block), data...)
 }
 
 // Complete resolves flags and sets up the factory.

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -180,6 +180,14 @@ func (o *GetOptions) Complete(cmd *cobra.Command, args []string) error {
 
 	o.NoHeaders = cmdutil.GetFlagBool(cmd, "no-headers")
 
+	// If the user didn't pass --template, resolve the per-context/per-namespace
+	// default from config.yaml, falling back to "default".
+	if !cmd.Flag("template").Changed {
+		if cfg, err := utils.LoadConfig(); err == nil {
+			o.Template = cfg.ResolveDefaultTemplate(o.Context, o.Namespace)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -3,6 +3,7 @@ package get
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -55,6 +56,7 @@ type GetOptions struct {
 	TemplateRootPath  string
 	EnableCustomTable bool
 	Columns           []string
+	Output            string
 
 	factory cmdutil.Factory
 	args    []string
@@ -177,6 +179,10 @@ func (o *GetOptions) list() error {
 		return err
 	}
 
+	if o.Output != "" {
+		return o.emitStructured(printer, infos)
+	}
+
 	w := printers.GetNewTabWriter(os.Stdout)
 	for _, info := range infos {
 		if err := printer.PrintObj(info.Object, w); err != nil {
@@ -191,6 +197,17 @@ func (o *GetOptions) list() error {
 	}
 
 	return nil
+}
+
+func (o *GetOptions) emitStructured(printer *CustomColumnsPrinter, infos []*resource.Info) error {
+	var rows [][]string
+	printer.RowSink = func(cols []string) { rows = append(rows, cols) }
+	for _, info := range infos {
+		if err := printer.PrintObj(info.Object, io.Discard); err != nil {
+			return fmt.Errorf("failed to render row: %w", err)
+		}
+	}
+	return renderRows(o.Out, o.Output, printer.Headers, rows)
 }
 
 func (o *GetOptions) watch() error {
@@ -378,6 +395,7 @@ in <root>/<kind>-<group>-<version>/<template>.yaml (falling back to .tpl).`,
 
 	cmd.Flags().StringVarP(&o.Template, "template", "t", "default", "Name of the column template to use (without extension).")
 	cmd.Flags().StringSliceVarP(&o.Columns, "columns", "c", nil, "Comma-separated list of column headers to display (subset of the template's columns, case-insensitive).")
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Output format. One of: json, yaml, csv. If empty, prints the standard table.")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use.")
 	cmd.Flags().BoolVar(&o.EnableCustomTable, "ctable", false, "Enable custom table output with borders.")

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -54,6 +54,7 @@ type GetOptions struct {
 	Context           string
 	TemplateRootPath  string
 	EnableCustomTable bool
+	Columns           []string
 
 	factory cmdutil.Factory
 	args    []string
@@ -317,6 +318,12 @@ func (o *GetOptions) createPrinter(infos []*resource.Info) (*CustomColumnsPrinte
 		return nil, err
 	}
 
+	if len(o.Columns) > 0 {
+		if err := printer.SelectColumns(o.Columns); err != nil {
+			return nil, err
+		}
+	}
+
 	if o.EnableCustomTable {
 		printer.WithCustomTable()
 	}
@@ -370,6 +377,7 @@ in <root>/<kind>-<group>-<version>/<template>.yaml (falling back to .tpl).`,
 	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "If specified, gets the subresource of the requested object.")
 
 	cmd.Flags().StringVarP(&o.Template, "template", "t", "default", "Name of the column template to use (without extension).")
+	cmd.Flags().StringSliceVarP(&o.Columns, "columns", "c", nil, "Comma-separated list of column headers to display (subset of the template's columns, case-insensitive).")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use.")
 	cmd.Flags().BoolVar(&o.EnableCustomTable, "ctable", false, "Enable custom table output with borders.")

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -57,6 +57,8 @@ type GetOptions struct {
 	EnableCustomTable bool
 	Columns           []string
 	Output            string
+	SortColumn        string
+	FilterExprs       []string
 
 	factory cmdutil.Factory
 	args    []string
@@ -179,7 +181,7 @@ func (o *GetOptions) list() error {
 		return err
 	}
 
-	if o.Output != "" {
+	if o.Output != "" || o.SortColumn != "" || len(o.FilterExprs) > 0 {
 		return o.emitStructured(printer, infos)
 	}
 
@@ -207,7 +209,27 @@ func (o *GetOptions) emitStructured(printer *CustomColumnsPrinter, infos []*reso
 			return fmt.Errorf("failed to render row: %w", err)
 		}
 	}
-	return renderRows(o.Out, o.Output, printer.Headers, rows)
+
+	if len(o.FilterExprs) > 0 {
+		filtered, err := filterRows(printer.Headers, rows, o.FilterExprs)
+		if err != nil {
+			return err
+		}
+		rows = filtered
+	}
+
+	if o.SortColumn != "" {
+		if err := sortRows(printer.Headers, rows, o.SortColumn); err != nil {
+			return err
+		}
+	}
+
+	if o.Output != "" {
+		return renderRows(o.Out, o.Output, printer.Headers, rows)
+	}
+
+	// No explicit -o: render the standard table using our own writer.
+	return renderRows(o.Out, "table", printer.Headers, rows)
 }
 
 func (o *GetOptions) watch() error {
@@ -396,6 +418,8 @@ in <root>/<kind>-<group>-<version>/<template>.yaml (falling back to .tpl).`,
 	cmd.Flags().StringVarP(&o.Template, "template", "t", "default", "Name of the column template to use (without extension).")
 	cmd.Flags().StringSliceVarP(&o.Columns, "columns", "c", nil, "Comma-separated list of column headers to display (subset of the template's columns, case-insensitive).")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Output format. One of: json, yaml, csv. If empty, prints the standard table.")
+	cmd.Flags().StringVar(&o.SortColumn, "sort-by", "", "Column header to sort rows by (case-insensitive). Numeric strings sort numerically.")
+	cmd.Flags().StringArrayVar(&o.FilterExprs, "filter", nil, "Filter rows by column values: COL=val, COL!=val, COL~regex, COL!~regex (repeatable, ANDed).")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use.")
 	cmd.Flags().BoolVar(&o.EnableCustomTable, "ctable", false, "Enable custom table output with borders.")

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -8,13 +8,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kubectl-cwide/pkg/clients"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -155,17 +155,7 @@ func (o *GetOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 	o.TemplateRootPath = rootPath
 
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
-
-	if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
-		kubeConfigFlags.KubeConfig = ptr.To(v.Value.String())
-	}
-	if o.Context != "" {
-		kubeConfigFlags.Context = &o.Context
-	}
-
-	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	o.factory = cmdutil.NewFactory(matchVersionKubeConfigFlags)
+	o.factory = clients.FactoryFromCmd(cmd, o.Context)
 
 	if o.Namespace == "" {
 		o.Namespace, o.ExplicitNamespace, err = o.factory.ToRawKubeConfigLoader().Namespace()

--- a/pkg/cmd/get/output.go
+++ b/pkg/cmd/get/output.go
@@ -1,0 +1,68 @@
+package get
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// renderRows emits the collected rows in the requested format.
+func renderRows(out io.Writer, format string, headers []string, rows [][]string) error {
+	switch strings.ToLower(format) {
+	case "json":
+		objs := rowsAsObjects(headers, rows)
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(objs)
+	case "yaml":
+		objs := rowsAsObjects(headers, rows)
+		data, err := yaml.Marshal(objs)
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(data)
+		return err
+	case "csv":
+		w := csv.NewWriter(out)
+		defer w.Flush()
+		if len(headers) > 0 {
+			if err := w.Write(headers); err != nil {
+				return err
+			}
+		}
+		for _, r := range rows {
+			// pad short rows to header width so csv shape stays regular
+			if len(r) < len(headers) {
+				padded := make([]string, len(headers))
+				copy(padded, r)
+				r = padded
+			}
+			if err := w.Write(r); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format %q (expected json, yaml, or csv)", format)
+	}
+}
+
+func rowsAsObjects(headers []string, rows [][]string) []map[string]string {
+	objs := make([]map[string]string, 0, len(rows))
+	for _, r := range rows {
+		m := make(map[string]string, len(headers))
+		for i, h := range headers {
+			if i < len(r) {
+				m[h] = r[i]
+			} else {
+				m[h] = ""
+			}
+		}
+		objs = append(objs, m)
+	}
+	return objs
+}

--- a/pkg/cmd/get/output.go
+++ b/pkg/cmd/get/output.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/printers"
 )
 
 // renderRows emits the collected rows in the requested format.
@@ -46,9 +51,134 @@ func renderRows(out io.Writer, format string, headers []string, rows [][]string)
 			}
 		}
 		return nil
+	case "table", "":
+		w := printers.GetNewTabWriter(out)
+		defer w.Flush()
+		if len(headers) > 0 {
+			fmt.Fprintln(w, strings.Join(headers, "\t"))
+		}
+		for _, r := range rows {
+			fmt.Fprintln(w, strings.Join(r, "\t"))
+		}
+		return nil
 	default:
-		return fmt.Errorf("unsupported output format %q (expected json, yaml, or csv)", format)
+		return fmt.Errorf("unsupported output format %q (expected json, yaml, csv, or table)", format)
 	}
+}
+
+// filterRows keeps rows where every expression evaluates true.
+// Supported operators: =, ==, !=, ~ (regex match), !~ (regex non-match).
+// Column names are case-insensitive.
+func filterRows(headers []string, rows [][]string, exprs []string) ([][]string, error) {
+	preds := make([]filterPredicate, 0, len(exprs))
+	headerIdx := headerIndexMap(headers)
+	for _, e := range exprs {
+		p, err := parseFilterExpr(e, headerIdx)
+		if err != nil {
+			return nil, err
+		}
+		preds = append(preds, p)
+	}
+
+	out := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		keep := true
+		for _, p := range preds {
+			var cell string
+			if p.colIdx < len(r) {
+				cell = r[p.colIdx]
+			}
+			switch p.op {
+			case "=", "==":
+				if cell != p.value {
+					keep = false
+				}
+			case "!=":
+				if cell == p.value {
+					keep = false
+				}
+			case "~":
+				if !p.re.MatchString(cell) {
+					keep = false
+				}
+			case "!~":
+				if p.re.MatchString(cell) {
+					keep = false
+				}
+			}
+			if !keep {
+				break
+			}
+		}
+		if keep {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func headerIndexMap(headers []string) map[string]int {
+	m := make(map[string]int, len(headers))
+	for i, h := range headers {
+		m[strings.ToUpper(h)] = i
+	}
+	return m
+}
+
+type filterPredicate struct {
+	colIdx int
+	op     string
+	value  string
+	re     *regexp.Regexp
+}
+
+func parseFilterExpr(expr string, headerIdx map[string]int) (filterPredicate, error) {
+	// Order matters: match longer operators first.
+	for _, op := range []string{"!~", "!=", "==", "~", "="} {
+		if i := strings.Index(expr, op); i > 0 {
+			col := strings.TrimSpace(expr[:i])
+			val := expr[i+len(op):]
+			idx, ok := headerIdx[strings.ToUpper(col)]
+			if !ok {
+				return filterPredicate{}, fmt.Errorf("unknown column %q in filter %q", col, expr)
+			}
+			p := filterPredicate{colIdx: idx, op: op, value: val}
+			if op == "~" || op == "!~" {
+				re, err := regexp.Compile(val)
+				if err != nil {
+					return filterPredicate{}, fmt.Errorf("bad regex in filter %q: %w", expr, err)
+				}
+				p.re = re
+			}
+			return p, nil
+		}
+	}
+	return filterPredicate{}, fmt.Errorf("filter %q must contain =, ==, !=, ~, or !~", expr)
+}
+
+// sortRows sorts rows in place by the named column. Numeric strings sort
+// numerically; otherwise, lexicographically.
+func sortRows(headers []string, rows [][]string, colName string) error {
+	idx, ok := headerIndexMap(headers)[strings.ToUpper(colName)]
+	if !ok {
+		return fmt.Errorf("unknown sort-by column %q", colName)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		var a, b string
+		if idx < len(rows[i]) {
+			a = rows[i][idx]
+		}
+		if idx < len(rows[j]) {
+			b = rows[j][idx]
+		}
+		af, aErr := strconv.ParseFloat(a, 64)
+		bf, bErr := strconv.ParseFloat(b, 64)
+		if aErr == nil && bErr == nil {
+			return af < bf
+		}
+		return a < b
+	})
+	return nil
 }
 
 func rowsAsObjects(headers []string, rows [][]string) []map[string]string {

--- a/pkg/cmd/get/output_test.go
+++ b/pkg/cmd/get/output_test.go
@@ -1,0 +1,106 @@
+package get
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFilterRowsEquality(t *testing.T) {
+	headers := []string{"NAME", "STATUS"}
+	rows := [][]string{
+		{"a", "Running"},
+		{"b", "Pending"},
+		{"c", "Running"},
+	}
+	got, err := filterRows(headers, rows, []string{"STATUS=Running"})
+	if err != nil {
+		t.Fatalf("filter err: %v", err)
+	}
+	want := [][]string{{"a", "Running"}, {"c", "Running"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestFilterRowsRegex(t *testing.T) {
+	headers := []string{"NAME"}
+	rows := [][]string{{"pod-abc"}, {"svc-xyz"}, {"pod-def"}}
+	got, err := filterRows(headers, rows, []string{"NAME~^pod-"})
+	if err != nil {
+		t.Fatalf("filter err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 pods, got %d", len(got))
+	}
+}
+
+func TestFilterRowsNegation(t *testing.T) {
+	headers := []string{"AGE"}
+	rows := [][]string{{"1"}, {"2"}, {"3"}}
+	got, err := filterRows(headers, rows, []string{"AGE!=2"})
+	if err != nil {
+		t.Fatalf("filter err: %v", err)
+	}
+	if len(got) != 2 || got[0][0] == "2" || got[1][0] == "2" {
+		t.Fatalf("negation broken: %v", got)
+	}
+}
+
+func TestFilterRowsUnknownColumn(t *testing.T) {
+	_, err := filterRows([]string{"NAME"}, [][]string{{"a"}}, []string{"WAT=1"})
+	if err == nil {
+		t.Fatal("want error for unknown column, got nil")
+	}
+}
+
+func TestSortRowsNumeric(t *testing.T) {
+	headers := []string{"AGE"}
+	rows := [][]string{{"10"}, {"2"}, {"100"}}
+	if err := sortRows(headers, rows, "AGE"); err != nil {
+		t.Fatalf("sort err: %v", err)
+	}
+	// numeric sort → 2, 10, 100
+	want := [][]string{{"2"}, {"10"}, {"100"}}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("got %v, want %v", rows, want)
+	}
+}
+
+func TestSortRowsLexical(t *testing.T) {
+	headers := []string{"NAME"}
+	rows := [][]string{{"charlie"}, {"alpha"}, {"bravo"}}
+	if err := sortRows(headers, rows, "NAME"); err != nil {
+		t.Fatalf("sort err: %v", err)
+	}
+	if rows[0][0] != "alpha" || rows[1][0] != "bravo" || rows[2][0] != "charlie" {
+		t.Fatalf("lexical sort broken: %v", rows)
+	}
+}
+
+func TestRenderCSV(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderRows(&buf, "csv", []string{"NAME", "AGE"}, [][]string{{"a", "1"}, {"b,c", "2"}})
+	if err != nil {
+		t.Fatalf("csv render: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "NAME,AGE\n") {
+		t.Fatalf("no header line: %q", got)
+	}
+	if !strings.Contains(got, "\"b,c\",2") {
+		t.Fatalf("comma value not quoted: %q", got)
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderRows(&buf, "json", []string{"NAME"}, [][]string{{"a"}, {"b"}})
+	if err != nil {
+		t.Fatalf("json render: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"NAME": "a"`) {
+		t.Fatalf("unexpected json: %q", buf.String())
+	}
+}

--- a/pkg/cmd/initialization/init.go
+++ b/pkg/cmd/initialization/init.go
@@ -1,7 +1,6 @@
 package initialization
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,6 +48,7 @@ Existing template files are preserved and will not be overwritten.`,
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	config, err := ctrl.GetConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig: %w", err)
@@ -71,7 +71,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to add apiextensions v1 to scheme: %w", err)
 	}
 
-	crdList, err := clientSet.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+	crdList, err := clientSet.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list CRDs: %w", err)
 	}

--- a/pkg/cmd/marketplace/github.go
+++ b/pkg/cmd/marketplace/github.go
@@ -23,7 +23,16 @@ type GitHubEntry struct {
 
 // listContents fetches the contents of a directory in a GitHub repository.
 func listContents(repo, path string) ([]GitHubEntry, error) {
+	return listContentsAt(repo, path, "")
+}
+
+// listContentsAt fetches contents of a directory at a specific ref (branch,
+// tag, or commit SHA). Empty ref uses the repo's default branch.
+func listContentsAt(repo, path, ref string) ([]GitHubEntry, error) {
 	url := fmt.Sprintf("%s/repos/%s/contents/%s", apiBase, repo, path)
+	if ref != "" {
+		url += "?ref=" + ref
+	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/marketplace/install.go
+++ b/pkg/cmd/marketplace/install.go
@@ -35,9 +35,10 @@ is specified.`,
 			repo := cmd.Flag("repo").Value.String()
 			resource := cmd.Flag("resource").Value.String()
 			templateName := cmd.Flag("template").Value.String()
+			ref := cmd.Flag("ref").Value.String()
 
 			// Resolve the remote directory for this resource
-			entries, err := listContents(repo, basePath)
+			entries, err := listContentsAt(repo, basePath, ref)
 			if err != nil {
 				return fmt.Errorf("failed to list marketplace: %w", err)
 			}
@@ -61,7 +62,7 @@ is specified.`,
 			fileName := templateName + ".yaml"
 
 			// Find the file in the remote directory
-			files, err := listContents(repo, basePath+"/"+remoteDir)
+			files, err := listContentsAt(repo, basePath+"/"+remoteDir, ref)
 			if err != nil {
 				return fmt.Errorf("failed to list templates in %s: %w", remoteDir, err)
 			}
@@ -104,13 +105,26 @@ is specified.`,
 				return fmt.Errorf("failed to write template: %w", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Installed template: %s\n", localPath)
+			// Record the pin (best-effort; a failure here doesn't fail the install).
+			if lf, err := LoadLockFile(); err == nil {
+				lf.Upsert(MarketplacePin{
+					Repo: repo, Resource: resource, Template: templateName, Ref: ref,
+				})
+				_ = lf.Save()
+			}
+
+			if ref != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "Installed template: %s (pinned to %s)\n", localPath, ref)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Installed template: %s\n", localPath)
+			}
 			return nil
 		},
 	}
 
 	installCMD.Flags().StringP("resource", "r", "", "Resource type (e.g. pod, deployment)")
 	installCMD.Flags().StringP("template", "t", "", "Template name to install (without extension)")
+	installCMD.Flags().String("ref", "", "Pin to a specific git ref (branch, tag, or commit SHA). Recorded in ~/.kubectl-cwide/marketplace.lock.")
 	installCMD.Flags().BoolVar(&force, "force", false, "Overwrite existing template file")
 	installCMD.MarkFlagRequired("resource")
 	installCMD.MarkFlagRequired("template")

--- a/pkg/cmd/marketplace/lock.go
+++ b/pkg/cmd/marketplace/lock.go
@@ -1,0 +1,79 @@
+package marketplace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// lockFilePath returns the path to the marketplace lock file.
+func lockFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".kubectl-cwide", "marketplace.lock"), nil
+}
+
+// MarketplacePin records that a specific template was installed from a repo at a ref.
+type MarketplacePin struct {
+	Repo     string `yaml:"repo"`
+	Resource string `yaml:"resource"`
+	Template string `yaml:"template"`
+	Ref      string `yaml:"ref"`
+}
+
+// LockFile is the on-disk format for marketplace.lock.
+type LockFile struct {
+	Pins []MarketplacePin `yaml:"pins"`
+}
+
+// LoadLockFile reads ~/.kubectl-cwide/marketplace.lock, returning an empty
+// LockFile if it doesn't exist.
+func LoadLockFile() (*LockFile, error) {
+	path, err := lockFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &LockFile{}, nil
+		}
+		return nil, err
+	}
+	var lf LockFile
+	if err := yaml.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("parse lock file: %w", err)
+	}
+	return &lf, nil
+}
+
+// Save writes the lock file to disk, creating parent dirs as needed.
+func (lf *LockFile) Save() error {
+	path, err := lockFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// Upsert inserts or replaces a pin matching (repo, resource, template).
+func (lf *LockFile) Upsert(p MarketplacePin) {
+	for i, existing := range lf.Pins {
+		if existing.Repo == p.Repo && existing.Resource == p.Resource && existing.Template == p.Template {
+			lf.Pins[i] = p
+			return
+		}
+	}
+	lf.Pins = append(lf.Pins, p)
+}

--- a/pkg/cmd/marketplace/lock_test.go
+++ b/pkg/cmd/marketplace/lock_test.go
@@ -1,0 +1,38 @@
+package marketplace
+
+import "testing"
+
+func TestLockFileUpsertInsertsNew(t *testing.T) {
+	lf := &LockFile{}
+	lf.Upsert(MarketplacePin{Repo: "r", Resource: "pod", Template: "debug", Ref: "v1"})
+	if got := len(lf.Pins); got != 1 {
+		t.Fatalf("expected 1 pin, got %d", got)
+	}
+	if lf.Pins[0].Ref != "v1" {
+		t.Fatalf("expected ref v1, got %q", lf.Pins[0].Ref)
+	}
+}
+
+func TestLockFileUpsertReplacesExisting(t *testing.T) {
+	lf := &LockFile{Pins: []MarketplacePin{
+		{Repo: "r", Resource: "pod", Template: "debug", Ref: "v1"},
+	}}
+	lf.Upsert(MarketplacePin{Repo: "r", Resource: "pod", Template: "debug", Ref: "v2"})
+	if got := len(lf.Pins); got != 1 {
+		t.Fatalf("expected 1 pin after replace, got %d", got)
+	}
+	if lf.Pins[0].Ref != "v2" {
+		t.Fatalf("expected ref v2 after replace, got %q", lf.Pins[0].Ref)
+	}
+}
+
+func TestLockFileUpsertDistinguishesByAllKeys(t *testing.T) {
+	lf := &LockFile{Pins: []MarketplacePin{
+		{Repo: "r", Resource: "pod", Template: "debug", Ref: "v1"},
+	}}
+	// Different template — should insert, not replace.
+	lf.Upsert(MarketplacePin{Repo: "r", Resource: "pod", Template: "other", Ref: "v2"})
+	if got := len(lf.Pins); got != 2 {
+		t.Fatalf("expected 2 pins, got %d", got)
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/kubectl-cwide/pkg/cmd/alias"
+	"github.com/kubectl-cwide/pkg/cmd/completion"
 	"github.com/kubectl-cwide/pkg/cmd/config"
 	configmapCmd "github.com/kubectl-cwide/pkg/cmd/configmap"
 	"github.com/kubectl-cwide/pkg/cmd/get"
@@ -44,6 +45,7 @@ display resources using those templates.`,
 	cmd.AddCommand(configmapCmd.NewCmdConfigMap())
 	cmd.AddCommand(tree.NewCmdTree(streams))
 	cmd.AddCommand(alias.NewCmdAlias())
+	cmd.AddCommand(completion.NewCmdCompletion())
 
 	return cmd
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubectl-cwide/pkg/cmd/config"
 	configmapCmd "github.com/kubectl-cwide/pkg/cmd/configmap"
 	"github.com/kubectl-cwide/pkg/cmd/get"
+	"github.com/kubectl-cwide/pkg/parser/funcs"
 	"github.com/kubectl-cwide/pkg/cmd/initialization"
 	"github.com/kubectl-cwide/pkg/cmd/marketplace"
 	"github.com/kubectl-cwide/pkg/cmd/template"
@@ -29,6 +30,11 @@ expressions, Go text/template functions, and Helm-style helpers.
 Use 'init' to auto-generate templates for all resources in a cluster, then 'get' to
 display resources using those templates.`,
 		SilenceUsage: true,
+		PersistentPreRun: func(c *cobra.Command, args []string) {
+			if noColor, _ := c.Flags().GetBool("no-color"); noColor {
+				funcs.SetColorDisabled(true)
+			}
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			return c.Help()
 		},
@@ -36,6 +42,7 @@ display resources using those templates.`,
 
 	cmd.PersistentFlags().String("template-path", "/tmp/cwide", "Root directory for column template files")
 	cmd.PersistentFlags().String("kubeconfig", "", "Path to a kubeconfig file. If unset, the KUBECONFIG env var or default path is used")
+	cmd.PersistentFlags().Bool("no-color", false, "Disable ANSI color output (respects NO_COLOR env var as well)")
 
 	cmd.AddCommand(initialization.NewCmdInit())
 	cmd.AddCommand(get.NewCmdGet(streams))

--- a/pkg/cmd/template/edit.go
+++ b/pkg/cmd/template/edit.go
@@ -72,6 +72,10 @@ template name.`,
 				editor = "vi"
 			}
 
+			// Snapshot mtime + size so we can detect the file being
+			// overwritten mid-edit (e.g. by a concurrent configmap sync).
+			preStat, preErr := os.Stat(targetPath)
+
 			editorCmd := exec.Command(editor, targetPath)
 			editorCmd.Stdin = os.Stdin
 			editorCmd.Stdout = os.Stdout
@@ -79,6 +83,18 @@ template name.`,
 
 			if err := editorCmd.Run(); err != nil {
 				return fmt.Errorf("editor exited with error: %w", err)
+			}
+
+			if preErr == nil {
+				postStat, err := os.Stat(targetPath)
+				if err == nil && (postStat.ModTime() != preStat.ModTime() && postStat.Size() != preStat.Size()) {
+					// Both mtime AND size changed — user probably saved. Fine.
+				} else if err == nil && postStat.ModTime() != preStat.ModTime() && postStat.Size() == preStat.Size() {
+					// mtime changed but size didn't — possible sync overwrite of identical content.
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: %s mtime changed during edit but size is unchanged; a concurrent configmap sync may have run — re-check your changes\n",
+						targetPath)
+				}
 			}
 			return nil
 		},

--- a/pkg/cmd/template/lint.go
+++ b/pkg/cmd/template/lint.go
@@ -1,0 +1,96 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/util/jsonpath"
+
+	"github.com/kubectl-cwide/pkg/models"
+)
+
+func NewCmdLint() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint <template-file>",
+		Short: "Statically validate a column template file",
+		Long: `Parse a .yaml or .tpl template and check that:
+  - the file is syntactically valid
+  - every JSONPath field spec parses cleanly
+  - every text/template body parses cleanly (best-effort — no execution)
+
+Does NOT contact the cluster or resolve schema against a live API.`,
+		Example: `  # Lint one template
+  kubectl cwide template lint ~/.kubectl-cwide/templates/pod--v1/default.yaml
+
+  # Lint every template under a directory
+  find ~/.kubectl-cwide/templates -name '*.yaml' -exec kubectl cwide template lint {} \;`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return lintOne(cmd, args[0])
+		},
+	}
+}
+
+func lintOne(cmd *cobra.Command, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var problems []string
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".yaml", ".yml":
+		var tmpl models.YAMLTemplate
+		if err := yaml.Unmarshal(data, &tmpl); err != nil {
+			return fmt.Errorf("yaml parse: %w", err)
+		}
+		if len(tmpl.Columns) == 0 {
+			problems = append(problems, "template has no columns")
+		}
+		for i, c := range tmpl.Columns {
+			if c.Header == "" {
+				problems = append(problems, fmt.Sprintf("column[%d]: missing header", i))
+			}
+			if c.FieldSpec == "" && c.Template == "" {
+				problems = append(problems, fmt.Sprintf("column[%d] (%s): needs fieldSpec or template", i, c.Header))
+			}
+			if c.FieldSpec != "" {
+				if err := parseJSONPath(c.FieldSpec); err != nil {
+					problems = append(problems, fmt.Sprintf("column[%d] (%s): bad fieldSpec: %v", i, c.Header, err))
+				}
+			}
+		}
+	case ".tpl":
+		lines := strings.Split(string(data), "\n")
+		if len(lines) < 2 {
+			problems = append(problems, "tpl needs at least a header line and a spec line")
+		}
+	default:
+		return fmt.Errorf("unsupported extension %q (want .yaml, .yml, or .tpl)", ext)
+	}
+
+	if len(problems) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "OK  %s\n", path)
+		return nil
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "FAIL %s\n", path)
+	for _, p := range problems {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", p)
+	}
+	return fmt.Errorf("%d issue(s)", len(problems))
+}
+
+func parseJSONPath(expr string) error {
+	// Accept either bare `.foo.bar` or `{.foo.bar}` form; normalize to braces.
+	e := expr
+	if !strings.HasPrefix(e, "{") {
+		e = "{" + e + "}"
+	}
+	jp := jsonpath.New("lint")
+	return jp.Parse(e)
+}

--- a/pkg/cmd/template/lint_test.go
+++ b/pkg/cmd/template/lint_test.go
@@ -1,0 +1,54 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestLintGoodYAML(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.yaml")
+	body := `columns:
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: STATUS
+    fieldSpec: .status.phase
+`
+	if err := os.WriteFile(good, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	if err := lintOne(cmd, good); err != nil {
+		t.Fatalf("good template errored: %v", err)
+	}
+}
+
+func TestLintMissingHeader(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.yaml")
+	body := `columns:
+  - fieldSpec: .metadata.name
+`
+	if err := os.WriteFile(bad, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	if err := lintOne(cmd, bad); err == nil {
+		t.Fatal("missing header should have failed lint")
+	}
+}
+
+func TestLintUnsupportedExt(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.md")
+	if err := os.WriteFile(bad, []byte("nope"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	if err := lintOne(cmd, bad); err == nil {
+		t.Fatal("wrong extension should have failed")
+	}
+}

--- a/pkg/cmd/template/root.go
+++ b/pkg/cmd/template/root.go
@@ -20,6 +20,7 @@ the config file created by 'init').`,
 	templateCMD.AddCommand(NewCmdTemplateList())
 	templateCMD.AddCommand(NewCmdCreate())
 	templateCMD.AddCommand(NewCmdEdit())
+	templateCMD.AddCommand(NewCmdLint())
 
 	return templateCMD
 }

--- a/pkg/cmd/template/root.go
+++ b/pkg/cmd/template/root.go
@@ -21,6 +21,7 @@ the config file created by 'init').`,
 	templateCMD.AddCommand(NewCmdCreate())
 	templateCMD.AddCommand(NewCmdEdit())
 	templateCMD.AddCommand(NewCmdLint())
+	templateCMD.AddCommand(NewCmdScaffold())
 
 	return templateCMD
 }

--- a/pkg/cmd/template/scaffold.go
+++ b/pkg/cmd/template/scaffold.go
@@ -1,0 +1,50 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdScaffold creates a stub YAML template with common columns filled in
+// and the rest commented out for the user to enable.
+func NewCmdScaffold() *cobra.Command {
+	return &cobra.Command{
+		Use:   "scaffold <resource>",
+		Short: "Print a starter template for a resource type",
+		Long: `Emit a YAML template body with a handful of common columns (name, namespace,
+age) filled in, plus a commented-out set of frequently-useful JSONPath
+expressions you can uncomment.
+
+The output is written to stdout — pipe it to the destination path yourself.
+This is intended as a "first draft" — cwide's 'init' auto-generates a more
+complete template by inspecting the CRD schema.`,
+		Example: `  # Pipe to a template file
+  kubectl cwide template scaffold pod > ~/.kubectl-cwide/templates/pod--v1/starter.yaml`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := scaffoldFor(args[0])
+			_, err := fmt.Fprint(cmd.OutOrStdout(), body)
+			return err
+		},
+	}
+}
+
+func scaffoldFor(kind string) string {
+	kind = strings.ToLower(kind)
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Starter template for %s. Uncomment or edit columns as needed.\n", kind)
+	b.WriteString("columns:\n")
+	b.WriteString("  - header: NAMESPACE\n    fieldSpec: .metadata.namespace\n")
+	b.WriteString("  - header: NAME\n    fieldSpec: .metadata.name\n")
+	b.WriteString("  - header: AGE\n    fieldSpec: .metadata.creationTimestamp\n")
+	b.WriteString("\n")
+	b.WriteString("  # --- commonly useful fields; uncomment to include ---\n")
+	b.WriteString("  # - header: STATUS\n  #   fieldSpec: .status.phase\n")
+	b.WriteString("  # - header: LABELS\n  #   template: '{{ range $k, $v := .metadata.labels }}{{$k}}={{$v}} {{ end }}'\n")
+	b.WriteString("  # - header: OWNER\n  #   fieldSpec: .metadata.ownerReferences[0].name\n")
+	b.WriteString("  # - header: RESOURCE_VERSION\n  #   fieldSpec: .metadata.resourceVersion\n")
+	b.WriteString("  # - header: FINALIZERS\n  #   template: '{{ range .metadata.finalizers }}{{ . }} {{ end }}'\n")
+	return b.String()
+}

--- a/pkg/cmd/tree/render.go
+++ b/pkg/cmd/tree/render.go
@@ -7,21 +7,38 @@ import (
 
 	"github.com/xlab/treeprint"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
 // RenderTree prints the tree to out using Unicode box-drawing characters.
-func RenderTree(root *TreeNode, out io.Writer) {
+// maxDepth <= 0 means unbounded. Cycles (revisits of the same UID) are broken
+// with a "(cycle)" marker so the walk always terminates.
+func RenderTree(root *TreeNode, out io.Writer, maxDepth int) {
 	t := treeprint.NewWithRoot(formatNode(root))
-	addChildren(t, root)
+	visited := map[types.UID]bool{root.UID: true}
+	addChildren(t, root, visited, 1, maxDepth)
 	fmt.Fprint(out, t.String())
 }
 
-func addChildren(branch treeprint.Tree, node *TreeNode) {
+func addChildren(branch treeprint.Tree, node *TreeNode, visited map[types.UID]bool, depth, maxDepth int) {
+	if maxDepth > 0 && depth > maxDepth {
+		if len(node.Children) > 0 {
+			branch.AddNode(fmt.Sprintf("... (%d more, --max-depth=%d)", len(node.Children), maxDepth))
+		}
+		return
+	}
 	for _, child := range node.Children {
+		if child.UID != "" && visited[child.UID] {
+			branch.AddNode(formatNode(child) + "  (cycle)")
+			continue
+		}
+		if child.UID != "" {
+			visited[child.UID] = true
+		}
 		if len(child.Children) > 0 {
 			sub := branch.AddBranch(formatNode(child))
-			addChildren(sub, child)
+			addChildren(sub, child, visited, depth+1, maxDepth)
 		} else {
 			branch.AddNode(formatNode(child))
 		}

--- a/pkg/cmd/tree/render_test.go
+++ b/pkg/cmd/tree/render_test.go
@@ -155,7 +155,7 @@ func TestRenderTree(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	RenderTree(root, &buf)
+	RenderTree(root, &buf, 0)
 	output := buf.String()
 
 	// Verify structure

--- a/pkg/cmd/tree/reverse.go
+++ b/pkg/cmd/tree/reverse.go
@@ -1,0 +1,81 @@
+package tree
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// runReverse walks upward from the given node via ownerReferences, producing a
+// tree rooted at the topmost ancestor and rendered downward toward the caller's
+// resource. Best-effort: if an ownerRef points to a Kind that doesn't map to
+// a resource we can list, the chain stops there.
+func (o *TreeOptions) runReverse(ctx context.Context, start *TreeNode) error {
+	chain := []*TreeNode{start}
+	visited := map[types.UID]bool{start.UID: true}
+
+	cur := start
+	for {
+		refs := cur.Object.GetOwnerReferences()
+		if len(refs) == 0 {
+			break
+		}
+		ref := pickController(refs)
+		gvr, err := o.fetchAncestorGVR(ref)
+		if err != nil {
+			break // Kind not mappable — stop rather than fail the render.
+		}
+		parentObj, err := o.dynClient.Resource(gvr).Namespace(cur.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch ancestor %s/%s: %w", ref.Kind, ref.Name, err)
+		}
+		parent := nodeFromUnstructured(parentObj)
+		if visited[parent.UID] {
+			break // cycle
+		}
+		visited[parent.UID] = true
+		chain = append(chain, parent)
+		cur = parent
+	}
+
+	// Linear parent→child list: chain[len-1] is topmost ancestor.
+	root := chain[len(chain)-1]
+	prev := root
+	for i := len(chain) - 2; i >= 0; i-- {
+		prev.Children = []*TreeNode{chain[i]}
+		prev = chain[i]
+	}
+	RenderTree(root, o.Out, o.MaxDepth)
+	return nil
+}
+
+func pickController(refs []metav1.OwnerReference) metav1.OwnerReference {
+	for _, r := range refs {
+		if r.Controller != nil && *r.Controller {
+			return r
+		}
+	}
+	return refs[0]
+}
+
+func splitAPIVersion(apiVersion string) (group, version string) {
+	if i := strings.Index(apiVersion, "/"); i >= 0 {
+		return apiVersion[:i], apiVersion[i+1:]
+	}
+	return "", apiVersion
+}
+
+// fetchAncestorGVR resolves an ownerReference's Kind+APIVersion to a GVR.
+func (o *TreeOptions) fetchAncestorGVR(ref metav1.OwnerReference) (schema.GroupVersionResource, error) {
+	group, version := splitAPIVersion(ref.APIVersion)
+	gk := schema.GroupKind{Group: group, Kind: ref.Kind}
+	mapping, err := o.restMapper.RESTMapping(gk, version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
+}

--- a/pkg/cmd/tree/tree.go
+++ b/pkg/cmd/tree/tree.go
@@ -41,6 +41,7 @@ type TreeOptions struct {
 
 	RulesFile    string
 	RelatedFlags []string
+	MaxDepth     int
 
 	rootResource string
 	rootName     string
@@ -97,6 +98,7 @@ Binding types:
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "Namespace scope for this request")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List across all namespaces")
+	cmd.Flags().IntVar(&o.MaxDepth, "max-depth", 0, "Maximum tree depth to render; 0 means unbounded. Cycles are always broken with a (cycle) marker.")
 
 	return cmd
 }
@@ -273,7 +275,7 @@ func (o *TreeOptions) Run(ctx context.Context) error {
 		}
 	}
 
-	RenderTree(rootNode, o.Out)
+	RenderTree(rootNode, o.Out, o.MaxDepth)
 	return nil
 }
 

--- a/pkg/cmd/tree/tree.go
+++ b/pkg/cmd/tree/tree.go
@@ -42,6 +42,7 @@ type TreeOptions struct {
 	RulesFile    string
 	RelatedFlags []string
 	MaxDepth     int
+	Reverse      bool
 
 	rootResource string
 	rootName     string
@@ -99,6 +100,7 @@ Binding types:
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List across all namespaces")
 	cmd.Flags().IntVar(&o.MaxDepth, "max-depth", 0, "Maximum tree depth to render; 0 means unbounded. Cycles are always broken with a (cycle) marker.")
+	cmd.Flags().BoolVar(&o.Reverse, "reverse", false, "Show ancestors (via ownerReferences) instead of descendants.")
 
 	return cmd
 }
@@ -183,6 +185,9 @@ func (o *TreeOptions) Validate() error {
 	if o.rootResource == "" || o.rootName == "" {
 		return fmt.Errorf("root resource and name are required")
 	}
+	if o.Reverse {
+		return nil // ancestor walk uses ownerReferences, no relations required
+	}
 	if len(o.relations) == 0 {
 		return fmt.Errorf("at least one relation is required (use --rules or --related)")
 	}
@@ -215,6 +220,10 @@ func (o *TreeOptions) Run(ctx context.Context) error {
 	}
 
 	rootNode := nodeFromUnstructured(rootObj)
+
+	if o.Reverse {
+		return o.runReverse(ctx, rootNode)
+	}
 
 	// Build tree: topological resolution by parent dependency
 	nodesByResource := map[string][]*TreeNode{

--- a/pkg/cmd/tree/tree.go
+++ b/pkg/cmd/tree/tree.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kubectl-cwide/pkg/clients"
 	"github.com/kubectl-cwide/pkg/models"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
@@ -15,11 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/dynamic"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/utils/ptr"
 )
 
 // TreeNode represents one resource in the tree.
@@ -119,20 +118,7 @@ func (o *TreeOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.rootResource = utils.ResolveAliasString(o.rootResource)
 
 	// Set up factory
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
-		WithDeprecatedPasswordFlag().
-		WithDiscoveryBurst(300).
-		WithDiscoveryQPS(50.0)
-
-	if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
-		kubeConfigFlags.KubeConfig = ptr.To(v.Value.String())
-	}
-	if o.Context != "" {
-		kubeConfigFlags.Context = &o.Context
-	}
-
-	matchVersionFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	o.factory = cmdutil.NewFactory(matchVersionFlags)
+	o.factory = clients.FactoryFromCmd(cmd, o.Context)
 
 	// Resolve namespace
 	var err error

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -9,6 +9,29 @@ type Config struct {
 	TemplatePath    string            `json:"templatePath" yaml:"templatePath"`
 	TemplateSources []string          `json:"templateSources,omitempty" yaml:"templateSources,omitempty"`
 	Aliases         map[string]string `json:"aliases,omitempty" yaml:"aliases,omitempty"`
+
+	// DefaultTemplateContext overrides the "default" template name per
+	// kubeconfig context (e.g. {"prod": "compact", "dev": "verbose"}).
+	DefaultTemplateContext map[string]string `json:"defaultTemplateContext,omitempty" yaml:"defaultTemplateContext,omitempty"`
+	// DefaultTemplateNamespace overrides per namespace. Namespace overrides
+	// context if both match.
+	DefaultTemplateNamespace map[string]string `json:"defaultTemplateNamespace,omitempty" yaml:"defaultTemplateNamespace,omitempty"`
+}
+
+// ResolveDefaultTemplate picks the effective default template name for the
+// given (context, namespace) pair. Precedence: namespace > context > "default".
+func (c *Config) ResolveDefaultTemplate(kubeCtx, namespace string) string {
+	if namespace != "" {
+		if t, ok := c.DefaultTemplateNamespace[namespace]; ok && t != "" {
+			return t
+		}
+	}
+	if kubeCtx != "" {
+		if t, ok := c.DefaultTemplateContext[kubeCtx]; ok && t != "" {
+			return t
+		}
+	}
+	return "default"
 }
 
 type CRDProperty struct {

--- a/pkg/parser/funcs/builtins.go
+++ b/pkg/parser/funcs/builtins.go
@@ -3,11 +3,34 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/duration"
 )
+
+// colorDisabled overrides the NO_COLOR env var when set to true.
+// Set via SetColorDisabled (from the --no-color flag on the root command).
+var colorDisabled atomic.Bool
+
+// SetColorDisabled forces color output on or off regardless of NO_COLOR env.
+func SetColorDisabled(disabled bool) {
+	colorDisabled.Store(disabled)
+}
+
+// colorEnabled reports whether ANSI color escapes should be emitted.
+// It's disabled when NO_COLOR is set (any value) or SetColorDisabled(true) was called.
+func colorEnabled() bool {
+	if colorDisabled.Load() {
+		return false
+	}
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	return true
+}
 
 // HumanBytes formats an integer or numeric-string byte count using SI-like
 // binary units (KiB, MiB, GiB, TiB, PiB). Non-numeric input is returned as-is.
@@ -76,7 +99,7 @@ func B64Dec(s string) string {
 // color: one of "red", "green", "yellow", "blue", "cyan", "magenta", "gray".
 // Unrecognized colors return the text unwrapped.
 func ColorIf(cond bool, color, text string) string {
-	if !cond {
+	if !cond || !colorEnabled() {
 		return text
 	}
 	code, ok := ansiColorCodes[color]

--- a/pkg/parser/funcs/builtins.go
+++ b/pkg/parser/funcs/builtins.go
@@ -1,0 +1,161 @@
+package funcs
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+// HumanBytes formats an integer or numeric-string byte count using SI-like
+// binary units (KiB, MiB, GiB, TiB, PiB). Non-numeric input is returned as-is.
+func HumanBytes(v interface{}) string {
+	n, ok := toInt64(v)
+	if !ok {
+		if s, isStr := v.(string); isStr {
+			return s
+		}
+		return ""
+	}
+	if n < 0 {
+		return "-" + HumanBytes(-n)
+	}
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	suffix := "KMGTPE"[exp]
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), suffix)
+}
+
+// Age formats an RFC3339 timestamp string as a human-readable duration since
+// then (e.g. "3d", "5h12m"). Empty or unparseable input returns "".
+func Age(v interface{}) string {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return ""
+	}
+	return duration.HumanDuration(time.Since(t))
+}
+
+// Truncate cuts a string at n runes and appends "…" if it was truncated.
+// n <= 0 returns the input unchanged.
+func Truncate(n int, s string) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}
+
+// B64Dec base64-decodes a string. On decode error, returns the input unchanged.
+// Handy for viewing Secret data keys in templates.
+func B64Dec(s string) string {
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return s
+	}
+	return string(data)
+}
+
+// ColorIf wraps `text` in a terminal color code when `cond` is truthy.
+// color: one of "red", "green", "yellow", "blue", "cyan", "magenta", "gray".
+// Unrecognized colors return the text unwrapped.
+func ColorIf(cond bool, color, text string) string {
+	if !cond {
+		return text
+	}
+	code, ok := ansiColorCodes[color]
+	if !ok {
+		return text
+	}
+	return "\x1b[" + code + "m" + text + "\x1b[0m"
+}
+
+var ansiColorCodes = map[string]string{
+	"red":     "31",
+	"green":   "32",
+	"yellow":  "33",
+	"blue":    "34",
+	"magenta": "35",
+	"cyan":    "36",
+	"gray":    "90",
+}
+
+// SafeIndex walks a nested map/slice structure by keys/indices, returning
+// "" (or the zero value) if any level is missing. String keys index maps;
+// integer keys or numeric strings index slices.
+//
+// Example: {{ safeIndex . "status" "containerStatuses" 0 "restartCount" }}
+func SafeIndex(root interface{}, path ...interface{}) interface{} {
+	cur := root
+	for _, p := range path {
+		if cur == nil {
+			return ""
+		}
+		switch v := cur.(type) {
+		case map[string]interface{}:
+			key, ok := p.(string)
+			if !ok {
+				return ""
+			}
+			cur = v[key]
+		case []interface{}:
+			idx, ok := toInt(p)
+			if !ok || idx < 0 || idx >= len(v) {
+				return ""
+			}
+			cur = v[idx]
+		default:
+			return ""
+		}
+	}
+	if cur == nil {
+		return ""
+	}
+	return cur
+}
+
+func toInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float32:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	case string:
+		i, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	}
+	return 0, false
+}
+
+func toInt(v interface{}) (int, bool) {
+	n, ok := toInt64(v)
+	if !ok {
+		return 0, false
+	}
+	return int(n), true
+}

--- a/pkg/parser/funcs/builtins_test.go
+++ b/pkg/parser/funcs/builtins_test.go
@@ -1,0 +1,89 @@
+package funcs
+
+import (
+	"os"
+	"testing"
+)
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want string
+	}{
+		{int64(0), "0 B"},
+		{int64(1023), "1023 B"},
+		{int64(1024), "1.0 KiB"},
+		{int64(1024 * 1024), "1.0 MiB"},
+		{int64(-2048), "-2.0 KiB"},
+		{"4096", "4.0 KiB"},
+		{"not-a-number", "not-a-number"},
+	}
+	for _, tc := range cases {
+		got := HumanBytes(tc.in)
+		if got != tc.want {
+			t.Errorf("HumanBytes(%v) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := Truncate(5, "hello world"); got != "hello…" {
+		t.Errorf("truncate = %q", got)
+	}
+	if got := Truncate(0, "abc"); got != "abc" {
+		t.Errorf("truncate 0 = %q", got)
+	}
+	if got := Truncate(100, "short"); got != "short" {
+		t.Errorf("no-op truncate = %q", got)
+	}
+}
+
+func TestB64Dec(t *testing.T) {
+	if got := B64Dec("aGVsbG8="); got != "hello" {
+		t.Errorf("b64dec = %q", got)
+	}
+	// bad input returns as-is
+	if got := B64Dec("not*base64"); got != "not*base64" {
+		t.Errorf("b64dec bad = %q", got)
+	}
+}
+
+func TestColorIfRespectsNoColorEnv(t *testing.T) {
+	// Force enable so we start from a known state, then set NO_COLOR.
+	SetColorDisabled(false)
+	old, hadOld := os.LookupEnv("NO_COLOR")
+	os.Setenv("NO_COLOR", "1")
+	defer func() {
+		if hadOld {
+			os.Setenv("NO_COLOR", old)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+	}()
+
+	got := ColorIf(true, "red", "err")
+	if got != "err" {
+		t.Errorf("expected no color escapes when NO_COLOR set; got %q", got)
+	}
+}
+
+func TestSafeIndex(t *testing.T) {
+	root := map[string]interface{}{
+		"status": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "app"},
+			},
+		},
+	}
+	if got := SafeIndex(root, "status", "containers", 0, "name"); got != "app" {
+		t.Errorf("safeIndex = %v", got)
+	}
+	// Missing intermediate returns empty string.
+	if got := SafeIndex(root, "status", "missing", 0); got != "" {
+		t.Errorf("safeIndex missing = %v", got)
+	}
+	// Out-of-range slice index returns empty string.
+	if got := SafeIndex(root, "status", "containers", 99, "name"); got != "" {
+		t.Errorf("safeIndex OOB = %v", got)
+	}
+}

--- a/pkg/parser/funcs/funcs.go
+++ b/pkg/parser/funcs/funcs.go
@@ -33,6 +33,14 @@ var DefaultMap = template.FuncMap{
 	"include":       includeFun(nil, map[string]int{}),
 	"tpl":           tplFun(nil, map[string]int{}, false),
 	"progressBar":   progressBar,
+
+	// General-purpose helpers for column templates.
+	"humanBytes": HumanBytes,
+	"age":        Age,
+	"truncate":   Truncate,
+	"b64dec":     B64Dec,
+	"colorIf":    ColorIf,
+	"safeIndex":  SafeIndex,
 }
 
 // toYAML takes an interface, marshals it to yaml, and returns a string. It will

--- a/templates/native/README.md
+++ b/templates/native/README.md
@@ -1,0 +1,64 @@
+# Curated Native Kubernetes Templates
+
+A set of hand-tuned custom-column templates for the most common built-in Kubernetes resources. They surface information that `kubectl get -o wide` omits (image, resource requests/limits, probe endpoints, HPA metrics, PV volume source, etc.) so you spend less time in `describe` and `-o yaml`.
+
+## Install
+
+Two ways to use them.
+
+### Point cwide at this directory
+```sh
+kubectl cwide get pod --template-path ./templates/native
+```
+
+### Copy into your own template root
+```sh
+kubectl cwide init --template-path ~/.cwide-templates
+cp -r templates/native/* ~/.cwide-templates/
+```
+
+## What's included
+
+| Resource | Template | What it adds over `kubectl get` |
+|---|---|---|
+| `pod` | `default` | Reason (CrashLoopBackOff/ImagePullBackOff), summed restart count, node, pod IP, QoS |
+| `pod` | `resources` | Per-pod CPU/memory requests and limits, QoS class |
+| `pod` | `probes` | Liveness/readiness/startup probe endpoints |
+| `pod` | `images` | Container names, image tags, imagePullPolicy |
+| `deployment` | `default` | Ready/desired ratio, strategy, first image, progress condition reason |
+| `statefulset` | `default` | Current vs updated replicas, headless service, update strategy, image |
+| `daemonset` | `default` | Desired/current/ready/available/misscheduled, node selector |
+| `replicaset` | `default` | Owner reference (Deployment name), image |
+| `service` | `default` | External IP, ports:nodePorts, selector labels |
+| `node` | `default` | Ready status, roles, kubelet version, internal IP, OS/kernel, runtime, allocatable, schedulability |
+| `persistentvolumeclaim` | `default` | Bound volume, capacity, access modes, storage class, volume mode |
+| `persistentvolume` | `default` | Capacity, reclaim policy, claim, storage class, underlying volume source (csi/hostPath/nfs/…) |
+| `horizontalpodautoscaler` | `default` | Metric type/name, current utilization %, min/max/current/desired replicas |
+| `ingress` | `default` | Class, hosts, address, ports, path → backend mapping |
+| `job` | `default` | Completions ratio, active/failed counts, condition, start→completion window |
+| `cronjob` | `default` | Schedule, timezone, suspend, active count, last schedule/success, concurrency policy |
+| `configmap` | `default` | Key count (regular and binary), owner reference |
+| `secret` | `default` | Type, list of key names, owner reference |
+| `event` | `default` | Last seen, type, reason, involved object, source, count, message |
+
+## Usage
+
+Once installed, get uses the `default` template automatically:
+```sh
+kubectl cwide get pod -A
+```
+
+Switch to a non-default template with `-t`:
+```sh
+kubectl cwide get pod -t resources
+kubectl cwide get pod -t probes
+kubectl cwide get pod -t images
+```
+
+## Contributing
+
+If you improve one of these or add a new resource, open a PR. Guidelines:
+- Prefer `fieldSpec` (JSONPath) for simple fields; use `template` only when you need computation.
+- Guard nil paths (`.status.readyReplicas | default 0`) — otherwise pending resources will render `<no value>`.
+- Keep `AGE` last so it prints as a relative duration in the default column formatter.
+- Include `NAMESPACE` first when the resource is namespaced, so `-A` output stays readable.

--- a/templates/native/configmap--v1/default.yaml
+++ b/templates/native/configmap--v1/default.yaml
@@ -1,0 +1,13 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: KEYS
+    template: '{{ len (.data | default dict) }}'
+  - header: BINARY_KEYS
+    template: '{{ len (.binaryData | default dict) }}'
+  - header: OWNER
+    template: '{{- range .metadata.ownerReferences -}}{{ .kind }}/{{ .name }}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/cronjob-batch-v1/default.yaml
+++ b/templates/native/cronjob-batch-v1/default.yaml
@@ -1,0 +1,21 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: SCHEDULE
+    fieldSpec: .spec.schedule
+  - header: TIMEZONE
+    fieldSpec: .spec.timeZone
+  - header: SUSPEND
+    fieldSpec: .spec.suspend
+  - header: ACTIVE
+    template: '{{ len (.status.active | default list) }}'
+  - header: LAST_SCHEDULE
+    fieldSpec: .status.lastScheduleTime
+  - header: LAST_SUCCESS
+    fieldSpec: .status.lastSuccessfulTime
+  - header: CONCURRENCY
+    fieldSpec: .spec.concurrencyPolicy
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/daemonset-apps-v1/default.yaml
+++ b/templates/native/daemonset-apps-v1/default.yaml
@@ -1,0 +1,21 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: DESIRED
+    fieldSpec: .status.desiredNumberScheduled
+  - header: CURRENT
+    fieldSpec: .status.currentNumberScheduled
+  - header: READY
+    fieldSpec: .status.numberReady
+  - header: UP-TO-DATE
+    fieldSpec: .status.updatedNumberScheduled
+  - header: AVAILABLE
+    fieldSpec: .status.numberAvailable
+  - header: MISSCHEDULED
+    fieldSpec: .status.numberMisscheduled
+  - header: NODE_SELECTOR
+    template: '{{- range $k, $v := .spec.template.spec.nodeSelector -}}{{ $k }}={{ $v }} {{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/deployment-apps-v1/default.yaml
+++ b/templates/native/deployment-apps-v1/default.yaml
@@ -1,0 +1,19 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: READY
+    template: '{{ .status.readyReplicas | default 0 }}/{{ .spec.replicas | default 0 }}'
+  - header: UP-TO-DATE
+    fieldSpec: .status.updatedReplicas
+  - header: AVAILABLE
+    fieldSpec: .status.availableReplicas
+  - header: STRATEGY
+    fieldSpec: .spec.strategy.type
+  - header: IMAGE
+    template: '{{- range $i, $c := .spec.template.spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.image }}{{- end -}}'
+  - header: PROGRESS
+    template: '{{- range .status.conditions -}}{{- if eq .type "Progressing" -}}{{ .reason }}{{- end -}}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/event--v1/default.yaml
+++ b/templates/native/event--v1/default.yaml
@@ -1,0 +1,17 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: LAST_SEEN
+    template: '{{ .lastTimestamp | default .eventTime | default .metadata.creationTimestamp }}'
+  - header: TYPE
+    fieldSpec: .type
+  - header: REASON
+    fieldSpec: .reason
+  - header: OBJECT
+    template: '{{ .involvedObject.kind }}/{{ .involvedObject.name }}'
+  - header: SOURCE
+    template: '{{ .source.component }}{{ if .source.host }}@{{ .source.host }}{{ end }}'
+  - header: COUNT
+    fieldSpec: .count
+  - header: MESSAGE
+    fieldSpec: .message

--- a/templates/native/horizontalpodautoscaler-autoscaling-v2/default.yaml
+++ b/templates/native/horizontalpodautoscaler-autoscaling-v2/default.yaml
@@ -1,0 +1,21 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: REFERENCE
+    template: '{{ .spec.scaleTargetRef.kind }}/{{ .spec.scaleTargetRef.name }}'
+  - header: METRICS
+    template: '{{- range $i, $m := .spec.metrics -}}{{- if $i -}},{{- end -}}{{ $m.type }}{{- if $m.resource -}}:{{ $m.resource.name }}{{- end -}}{{- end -}}'
+  - header: TARGETS
+    template: '{{- range $i, $m := .status.currentMetrics -}}{{- if $i -}},{{- end -}}{{- if $m.resource -}}{{ $m.resource.current.averageUtilization | default "-" }}%{{- end -}}{{- end -}}'
+  - header: MIN
+    fieldSpec: .spec.minReplicas
+  - header: MAX
+    fieldSpec: .spec.maxReplicas
+  - header: CURRENT
+    fieldSpec: .status.currentReplicas
+  - header: DESIRED
+    fieldSpec: .status.desiredReplicas
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/ingress-networking.k8s.io-v1/default.yaml
+++ b/templates/native/ingress-networking.k8s.io-v1/default.yaml
@@ -1,0 +1,17 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: CLASS
+    fieldSpec: .spec.ingressClassName
+  - header: HOSTS
+    template: '{{- range $i, $r := .spec.rules -}}{{- if $i -}},{{- end -}}{{ $r.host }}{{- end -}}'
+  - header: ADDRESS
+    template: '{{- range $i, $ing := .status.loadBalancer.ingress -}}{{- if $i -}},{{- end -}}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}{{- end -}}'
+  - header: PORTS
+    template: '{{- if .spec.tls -}}80,443{{ else }}80{{ end }}'
+  - header: PATHS
+    template: '{{- range $r := .spec.rules -}}{{- range $p := $r.http.paths -}}{{ $p.path }}→{{ $p.backend.service.name }}:{{ $p.backend.service.port.number }} {{- end -}}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/job-batch-v1/default.yaml
+++ b/templates/native/job-batch-v1/default.yaml
@@ -1,0 +1,21 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: COMPLETIONS
+    template: '{{ .status.succeeded | default 0 }}/{{ .spec.completions | default 1 }}'
+  - header: ACTIVE
+    fieldSpec: .status.active
+  - header: FAILED
+    fieldSpec: .status.failed
+  - header: PARALLELISM
+    fieldSpec: .spec.parallelism
+  - header: BACKOFF_LIMIT
+    fieldSpec: .spec.backoffLimit
+  - header: STATUS
+    template: '{{- range .status.conditions -}}{{- if eq .status "True" -}}{{ .type }}{{- end -}}{{- end -}}'
+  - header: DURATION
+    template: '{{ if and .status.startTime .status.completionTime }}{{ .status.startTime }} → {{ .status.completionTime }}{{ else if .status.startTime }}started {{ .status.startTime }}{{ end }}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/node--v1/default.yaml
+++ b/templates/native/node--v1/default.yaml
@@ -1,0 +1,27 @@
+columns:
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: STATUS
+    template: '{{- range .status.conditions -}}{{- if eq .type "Ready" -}}{{ if eq .status "True" }}Ready{{ else }}NotReady{{ end }}{{- end -}}{{- end -}}'
+  - header: ROLES
+    template: '{{- $roles := "" -}}{{- range $k, $v := .metadata.labels -}}{{- if hasPrefix $k "node-role.kubernetes.io/" -}}{{- $roles = printf "%s%s " $roles (trimPrefix "node-role.kubernetes.io/" $k) -}}{{- end -}}{{- end -}}{{ if $roles }}{{ $roles }}{{ else }}<none>{{ end }}'
+  - header: VERSION
+    fieldSpec: .status.nodeInfo.kubeletVersion
+  - header: INTERNAL_IP
+    template: '{{- range .status.addresses -}}{{- if eq .type "InternalIP" -}}{{ .address }}{{- end -}}{{- end -}}'
+  - header: OS
+    fieldSpec: .status.nodeInfo.osImage
+  - header: KERNEL
+    fieldSpec: .status.nodeInfo.kernelVersion
+  - header: RUNTIME
+    fieldSpec: .status.nodeInfo.containerRuntimeVersion
+  - header: CPU
+    fieldSpec: .status.allocatable.cpu
+  - header: MEM
+    fieldSpec: .status.allocatable.memory
+  - header: PODS
+    fieldSpec: .status.allocatable.pods
+  - header: SCHEDULABLE
+    template: '{{ if .spec.unschedulable }}No{{ else }}Yes{{ end }}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/persistentvolume--v1/default.yaml
+++ b/templates/native/persistentvolume--v1/default.yaml
@@ -1,0 +1,19 @@
+columns:
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: CAPACITY
+    fieldSpec: .spec.capacity.storage
+  - header: ACCESS
+    template: '{{- range $i, $m := .spec.accessModes -}}{{- if $i -}},{{- end -}}{{ $m }}{{- end -}}'
+  - header: RECLAIM
+    fieldSpec: .spec.persistentVolumeReclaimPolicy
+  - header: STATUS
+    fieldSpec: .status.phase
+  - header: CLAIM
+    template: '{{- with .spec.claimRef -}}{{ .namespace }}/{{ .name }}{{- end -}}'
+  - header: STORAGECLASS
+    fieldSpec: .spec.storageClassName
+  - header: VOLUME_SOURCE
+    template: '{{- if .spec.hostPath -}}hostPath{{ else if .spec.nfs }}nfs{{ else if .spec.csi }}csi:{{ .spec.csi.driver }}{{ else if .spec.awsElasticBlockStore }}ebs{{ else if .spec.gcePersistentDisk }}gce{{ else if .spec.azureDisk }}azure{{ else }}other{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/persistentvolumeclaim--v1/default.yaml
+++ b/templates/native/persistentvolumeclaim--v1/default.yaml
@@ -1,0 +1,19 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: STATUS
+    fieldSpec: .status.phase
+  - header: VOLUME
+    fieldSpec: .spec.volumeName
+  - header: CAPACITY
+    fieldSpec: .status.capacity.storage
+  - header: ACCESS
+    template: '{{- range $i, $m := .spec.accessModes -}}{{- if $i -}},{{- end -}}{{ $m }}{{- end -}}'
+  - header: STORAGECLASS
+    fieldSpec: .spec.storageClassName
+  - header: VOLUME_MODE
+    fieldSpec: .spec.volumeMode
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/pod--v1/default.yaml
+++ b/templates/native/pod--v1/default.yaml
@@ -1,0 +1,21 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: READY
+    template: '{{- $r := 0 -}}{{- $t := 0 -}}{{- range .status.containerStatuses -}}{{- $t = add $t 1 -}}{{- if .ready -}}{{- $r = add $r 1 -}}{{- end -}}{{- end -}}{{ $r }}/{{ $t }}'
+  - header: PHASE
+    fieldSpec: .status.phase
+  - header: REASON
+    template: '{{- range .status.containerStatuses -}}{{- if .state.waiting -}}{{ .state.waiting.reason }}{{- else if .state.terminated -}}{{ .state.terminated.reason }}{{- end -}}{{- end -}}'
+  - header: RESTARTS
+    template: '{{- $n := 0 -}}{{- range .status.containerStatuses -}}{{- $n = add $n .restartCount -}}{{- end -}}{{ $n }}'
+  - header: NODE
+    fieldSpec: .spec.nodeName
+  - header: POD_IP
+    fieldSpec: .status.podIP
+  - header: QOS
+    fieldSpec: .status.qosClass
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/pod--v1/images.yaml
+++ b/templates/native/pod--v1/images.yaml
@@ -1,0 +1,11 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: CONTAINER
+    template: '{{- range $i, $c := .spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.name }}{{- end -}}'
+  - header: IMAGE
+    template: '{{- range $i, $c := .spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.image }}{{- end -}}'
+  - header: IMAGE_PULL_POLICY
+    template: '{{- range $i, $c := .spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.imagePullPolicy }}{{- end -}}'

--- a/templates/native/pod--v1/probes.yaml
+++ b/templates/native/pod--v1/probes.yaml
@@ -1,0 +1,11 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: LIVENESS
+    template: '{{- range .spec.containers -}}{{- if .livenessProbe -}}{{- with .livenessProbe.httpGet -}}http {{ .path }}:{{ .port }} {{- end -}}{{- with .livenessProbe.tcpSocket -}}tcp :{{ .port }} {{- end -}}{{- with .livenessProbe.exec -}}exec {{- end -}}{{- end -}}{{- end -}}'
+  - header: READINESS
+    template: '{{- range .spec.containers -}}{{- if .readinessProbe -}}{{- with .readinessProbe.httpGet -}}http {{ .path }}:{{ .port }} {{- end -}}{{- with .readinessProbe.tcpSocket -}}tcp :{{ .port }} {{- end -}}{{- with .readinessProbe.exec -}}exec {{- end -}}{{- end -}}{{- end -}}'
+  - header: STARTUP
+    template: '{{- range .spec.containers -}}{{- if .startupProbe -}}yes {{- end -}}{{- end -}}'

--- a/templates/native/pod--v1/resources.yaml
+++ b/templates/native/pod--v1/resources.yaml
@@ -1,0 +1,15 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: CPU_REQ
+    template: '{{- $sum := "" -}}{{- range .spec.containers -}}{{- if .resources.requests.cpu -}}{{- $sum = printf "%s%s " $sum .resources.requests.cpu -}}{{- end -}}{{- end -}}{{ if $sum }}{{ $sum }}{{ else }}-{{ end }}'
+  - header: CPU_LIM
+    template: '{{- $sum := "" -}}{{- range .spec.containers -}}{{- if .resources.limits.cpu -}}{{- $sum = printf "%s%s " $sum .resources.limits.cpu -}}{{- end -}}{{- end -}}{{ if $sum }}{{ $sum }}{{ else }}-{{ end }}'
+  - header: MEM_REQ
+    template: '{{- $sum := "" -}}{{- range .spec.containers -}}{{- if .resources.requests.memory -}}{{- $sum = printf "%s%s " $sum .resources.requests.memory -}}{{- end -}}{{- end -}}{{ if $sum }}{{ $sum }}{{ else }}-{{ end }}'
+  - header: MEM_LIM
+    template: '{{- $sum := "" -}}{{- range .spec.containers -}}{{- if .resources.limits.memory -}}{{- $sum = printf "%s%s " $sum .resources.limits.memory -}}{{- end -}}{{- end -}}{{ if $sum }}{{ $sum }}{{ else }}-{{ end }}'
+  - header: QOS
+    fieldSpec: .status.qosClass

--- a/templates/native/replicaset-apps-v1/default.yaml
+++ b/templates/native/replicaset-apps-v1/default.yaml
@@ -1,0 +1,17 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: DESIRED
+    fieldSpec: .spec.replicas
+  - header: CURRENT
+    fieldSpec: .status.replicas
+  - header: READY
+    fieldSpec: .status.readyReplicas
+  - header: OWNER
+    template: '{{- range .metadata.ownerReferences -}}{{ .kind }}/{{ .name }}{{- end -}}'
+  - header: IMAGE
+    template: '{{- range $i, $c := .spec.template.spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.image }}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/secret--v1/default.yaml
+++ b/templates/native/secret--v1/default.yaml
@@ -1,0 +1,13 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: TYPE
+    fieldSpec: .type
+  - header: KEYS
+    template: '{{- $keys := "" -}}{{- range $k, $v := .data -}}{{- $keys = printf "%s%s " $keys $k -}}{{- end -}}{{ if $keys }}{{ $keys }}{{ else }}<none>{{ end }}'
+  - header: OWNER
+    template: '{{- range .metadata.ownerReferences -}}{{ .kind }}/{{ .name }}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/service--v1/default.yaml
+++ b/templates/native/service--v1/default.yaml
@@ -1,0 +1,17 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: TYPE
+    fieldSpec: .spec.type
+  - header: CLUSTER_IP
+    fieldSpec: .spec.clusterIP
+  - header: EXTERNAL_IP
+    template: '{{- if .spec.externalIPs -}}{{- range $i, $ip := .spec.externalIPs -}}{{- if $i -}},{{- end -}}{{ $ip }}{{- end -}}{{- else if .status.loadBalancer.ingress -}}{{- range $i, $ing := .status.loadBalancer.ingress -}}{{- if $i -}},{{- end -}}{{ if $ing.ip }}{{ $ing.ip }}{{ else }}{{ $ing.hostname }}{{ end }}{{- end -}}{{- else -}}<none>{{- end -}}'
+  - header: PORTS
+    template: '{{- range $i, $p := .spec.ports -}}{{- if $i -}},{{- end -}}{{ $p.port }}{{ if $p.nodePort }}:{{ $p.nodePort }}{{ end }}/{{ $p.protocol }}{{- end -}}'
+  - header: SELECTOR
+    template: '{{- range $k, $v := .spec.selector -}}{{ $k }}={{ $v }} {{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp

--- a/templates/native/statefulset-apps-v1/default.yaml
+++ b/templates/native/statefulset-apps-v1/default.yaml
@@ -1,0 +1,19 @@
+columns:
+  - header: NAMESPACE
+    fieldSpec: .metadata.namespace
+  - header: NAME
+    fieldSpec: .metadata.name
+  - header: READY
+    template: '{{ .status.readyReplicas | default 0 }}/{{ .spec.replicas | default 0 }}'
+  - header: CURRENT
+    fieldSpec: .status.currentReplicas
+  - header: UPDATED
+    fieldSpec: .status.updatedReplicas
+  - header: SERVICE
+    fieldSpec: .spec.serviceName
+  - header: UPDATE_STRATEGY
+    fieldSpec: .spec.updateStrategy.type
+  - header: IMAGE
+    template: '{{- range $i, $c := .spec.template.spec.containers -}}{{- if $i -}},{{- end -}}{{ $c.image }}{{- end -}}'
+  - header: AGE
+    fieldSpec: .metadata.creationTimestamp


### PR DESCRIPTION
# brainstorm/auto — autonomous loop over brainstorm.md

This PR is the output of a single autonomous run through the task list in `brainstorm.md`. Every implemented item is one commit; every skipped item is called out below with the reason.

## Summary of what shipped

### Features
- **Shell completion** (`kubectl cwide completion bash|zsh|fish|powershell`)
- **`get -c/--columns`** — project a subset of the template's columns without editing it
- **`get -o json|yaml|csv`** — structured output of rendered rows
- **`get --sort-by=COL` and `get --filter=COL=val|~regex`** — post-render row transforms; multiple `--filter`s AND together
- **`tree --max-depth` and cycle detection** — safe rendering when ownerRef graphs loop
- **`tree --reverse`** — walk ancestors via ownerReferences
- **New template functions**: `humanBytes`, `age`, `truncate`, `b64dec`, `colorIf`, `safeIndex`
- **`--no-color`** root flag + `NO_COLOR` env respected
- **`template lint <file>`** — static validation of column templates
- **`template scaffold <resource>`** — starter template for a kind
- **Template inheritance**: `_shared/*.tpl` under template root is prepended to every template
- **Per-context / per-namespace default template** in `~/.kubectl-cwide/config.yaml`
- **Alias groups**: `alias set core pod,svc,cm` now works transparently
- **Cluster-scoped alias sync** via a reserved `__aliases__` key in the templates ConfigMap
- **Marketplace version pinning**: `install --ref <sha|tag>` writes `~/.kubectl-cwide/marketplace.lock`
- **Signal handling** at the root so Ctrl-C cancels mid-request cleanly

### Refactors / infra
- All `context.TODO()` sites now use `cmd.Context()`
- Client factory construction consolidated in `pkg/clients` (removes 4 copies of the same setup)
- Native k8s template set curated under `templates/native/`
- Cookbook (`docs/cookbook.md`) and migration guide (`docs/migration-from-custom-cols.md`)

### CI
- `test.yml` workflow: Go 1.23/1.24 × linux/mac/windows
- `e2e.yml` workflow: runs `hack/e2e-test.sh` against a kind cluster on every PR

### Test coverage
- `pkg/parser/funcs/builtins_test.go` — HumanBytes, Truncate, B64Dec, ColorIf, SafeIndex
- `pkg/cmd/marketplace/lock_test.go` — LockFile upsert semantics
- `pkg/cmd/template/lint_test.go` (added by hook — sanity checks lint output)

### Housekeeping
- README typo fix (`kubectl-ciwe` → `kubectl-cwide`)
- Removed the previously-shipped `list all` command (already gone on `main` — pre-loop cleanup)

## Skipped (with reasons)

| # | Item | Why skipped |
|---|------|-------------|
| 22 | Marketplace signed templates | Needs real cosign/sigstore infra (KMS keys, transparency log, published signatures) — not viable from sandbox; needs owner decision on trust model |
| 23 | Marketplace private registries (OCI/S3/GitLab) | Each source needs its own client + auth + end-to-end tests; needs prioritization decision first |
| 24 | Marketplace publish command | Needs a real community index repo to PR against; no such repo exists yet (marketplace is index-in-source) |
| 25 | Interactive TUI (Bubbletea) | Project-scale work (list views, focus, fuzzy search, live data binding, tests); can't be honestly done in one loop iteration |
| 26 | `diff` command | Useful diff needs either live cluster + last-applied-configuration annotation, or git history, or explicit --from/--to — each a different feature |
| 27 | `get all-resources` partial-failure | Already correct — audited in-place, no code change needed |
| 28 | Discovery cache | `factory.ToDiscoveryClient()` is already a CachedDiscoveryClient (~/.kube/cache/discovery); no work to do |
| 29 | `template edit` race protection | File lock via os.O_EXCL solves single-host only; multi-host is the real failure mode. Needs design discussion |
| 30 | -A audit | Already consistent — audited, no change needed |
| 31 | Windows path handling | Audited — all filesystem paths use filepath.Join; only unrelated `/` uses are URL/GVK strings. Full support needs CI matrix (#36) to verify |
| 35 | Drop vendor dir | Affects offline builds and CI; policy call, not mechanical |
| 39 | Verify goreleaser + krew index | Needs live GitHub Actions observation for v0.7.0 — can't do from sandbox |
| 42 | Restructure README into `docs/` | Would break existing anchor links and reorganize content krew references. Individual doc pages added under `docs/` instead |

## Not covered (was implemented pre-loop or by hook)
- **Watch mode** — already present in `pkg/cmd/get/get.go` (`--watch`/`-w`)
- **Tree custom edge types** — already supported via `--rules` YAML

## Testing
- All existing tests pass: `go test ./...`
- New tests added (see above)
- CI matrix will exercise on Go 1.23/1.24 × linux/mac/windows once merged

## How to open

Because this sandbox can't reach github.com, please run manually:

```sh
gh pr create --repo reborn1867/kubectl-cwide \
  --base main --head brainstorm/auto \
  --title "brainstorm/auto: bulk implementation of brainstorm.md" \
  --body-file PR_BODY.md
```

or open through the GitHub web UI.
