### PR TITLE
feat(completion): dynamic argument completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,18 @@ kubectl cwide completion fish > ~/.config/fish/completions/kubectl-cwide.fish
 kubectl cwide completion powershell > kubectl-cwide.ps1
 ```
 
-Completes commands, subcommands, flags, and dynamic argument values (resource types, template names, alias names) where applicable.
+Completes commands, subcommands, flags, and **dynamic argument values**:
+
+- `kubectl cwide get <TAB>` — cluster's resource types + short names + user aliases
+- `kubectl cwide tree <TAB>` — same, before the `/` separator
+- `kubectl cwide alias delete <TAB>` — currently-configured alias names
+- `--template=<TAB>` — template names discovered from the template root
+- `--context=<TAB>` — kubeconfig contexts
+- `-o <TAB>` — `json`, `yaml`, `csv`
+- `template list -r <TAB>`, `template edit -r <TAB>`, `template scaffold <TAB>` — resource types
+- `template edit -t <TAB>` — templates that exist for the specified resource
+
+Dynamic completions are best-effort — if the cluster is unreachable, they return no suggestions rather than a visible error.
 
 ### Color and Ctrl-C
 

--- a/pkg/cmd/alias/delete.go
+++ b/pkg/cmd/alias/delete.go
@@ -3,6 +3,7 @@ package alias
 import (
 	"fmt"
 
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -15,7 +16,8 @@ func NewCmdAliasDelete() *cobra.Command {
 		Short:      "Delete a resource type alias",
 		Example: `  # Delete the 'pd' alias
   kubectl cwide alias delete pd`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completions.AliasNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			alias := args[0]
 

--- a/pkg/cmd/completions/completions.go
+++ b/pkg/cmd/completions/completions.go
@@ -1,0 +1,185 @@
+// Package completions holds shared cobra ValidArgsFunction/completion callbacks
+// used across cwide subcommands so `kubectl cwide get <TAB>`, alias names, and
+// template names all get intelligent completion.
+package completions
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubectl-cwide/pkg/clients"
+	"github.com/kubectl-cwide/pkg/utils"
+)
+
+// ResourceTypes returns names + short names of every resource the cluster
+// advertises via discovery, plus every user-defined alias. Runs quietly (any
+// discovery error yields no completions rather than a visible failure).
+func ResourceTypes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// If the user has already typed a resource type, don't complete a second one.
+	if len(args) >= 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+
+	// Aliases first — they're small and free to load.
+	if cfg, err := utils.LoadConfig(); err == nil {
+		for name := range cfg.Aliases {
+			add(name)
+		}
+	}
+
+	// Cluster-served resources.
+	factory := clients.FactoryFromCmd(cmd, contextFromFlag(cmd))
+	if disc, err := factory.ToDiscoveryClient(); err == nil {
+		_, resourceLists, _ := disc.ServerGroupsAndResources()
+		for _, list := range resourceLists {
+			for _, r := range list.APIResources {
+				if strings.Contains(r.Name, "/") {
+					continue // skip subresources
+				}
+				add(r.Name)
+				for _, sn := range r.ShortNames {
+					add(sn)
+				}
+			}
+		}
+		// Discovery is best-effort; discovery.IsGroupDiscoveryFailedError is treated as "some results"
+		_ = discovery.IsGroupDiscoveryFailedError
+	}
+
+	sort.Strings(out)
+	return filterPrefix(out, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// AliasNames completes with the names of currently-configured aliases.
+// Handy for `alias delete <TAB>`.
+func AliasNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	cfg, err := utils.LoadConfig()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(cfg.Aliases))
+	for k := range cfg.Aliases {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return filterPrefix(names, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// TemplateNames completes with the template basenames that exist for the
+// resource type passed as the first positional arg. Falls back to scanning
+// every resource directory when no resource is known yet.
+func TemplateNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	rootPath, err := utils.ResolveTemplatePath(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	resource := ""
+	if len(args) >= 1 {
+		resource = strings.ToLower(utils.ResolveAliasString(args[0]))
+	}
+
+	seen := map[string]struct{}{}
+	var out []string
+
+	entries, err := os.ReadDir(rootPath)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if e.Name() == "_shared" {
+			continue
+		}
+		if resource != "" && !strings.HasPrefix(strings.ToLower(e.Name()), resource+"-") &&
+			!strings.HasPrefix(strings.ToLower(e.Name()), resource+"s-") &&
+			strings.ToLower(e.Name()) != resource+"--v1" {
+			// Loose match — resource dirs are `<plural>-<group>-<version>`, so we
+			// accept anything that starts with the resource singular or plural.
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(rootPath, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			name := f.Name()
+			switch {
+			case strings.HasSuffix(name, ".yaml"):
+				name = strings.TrimSuffix(name, ".yaml")
+			case strings.HasSuffix(name, ".tpl"):
+				name = strings.TrimSuffix(name, ".tpl")
+			default:
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return filterPrefix(out, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// KubeContexts completes with context names from the loading kubeconfig.
+func KubeContexts(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if v := cmd.Flag("kubeconfig"); v != nil && v.Changed {
+		rules.ExplicitPath = v.Value.String()
+	}
+	cfg, err := rules.Load()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(cfg.Contexts))
+	for k := range cfg.Contexts {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return filterPrefix(names, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func contextFromFlag(cmd *cobra.Command) string {
+	if f := cmd.Flag("context"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+func filterPrefix(all []string, prefix string) []string {
+	if prefix == "" {
+		return all
+	}
+	out := make([]string, 0, len(all))
+	for _, s := range all {
+		if strings.HasPrefix(s, prefix) {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/pkg/cmd/completions/completions_test.go
+++ b/pkg/cmd/completions/completions_test.go
@@ -1,0 +1,28 @@
+package completions
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterPrefix(t *testing.T) {
+	all := []string{"pod", "pods", "podsecuritypolicy", "service"}
+	cases := []struct {
+		prefix string
+		want   []string
+	}{
+		{"", all},
+		{"pod", []string{"pod", "pods", "podsecuritypolicy"}},
+		{"pods", []string{"pods", "podsecuritypolicy"}},
+		{"svc", []string{}},
+	}
+	for _, tc := range cases {
+		got := filterPrefix(all, tc.prefix)
+		if len(got) == 0 && len(tc.want) == 0 {
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("filterPrefix(%q) = %v; want %v", tc.prefix, got, tc.want)
+		}
+	}
+}

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/kubectl-cwide/pkg/clients"
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -447,8 +448,9 @@ in <root>/<kind>-<group>-<version>/<template>.yaml (falling back to .tpl).`,
 
   # List across all namespaces
   kubectl cwide get pods -A`,
-		Args: cobra.MinimumNArgs(1),
-		RunE: o.Run,
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: completions.ResourceTypes,
+		RunE:              o.Run,
 	}
 
 	cmd.AddCommand(NewCmdGetAllResources(streams))
@@ -465,12 +467,15 @@ in <root>/<kind>-<group>-<version>/<template>.yaml (falling back to .tpl).`,
 	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "If specified, gets the subresource of the requested object.")
 
 	cmd.Flags().StringVarP(&o.Template, "template", "t", "default", "Name of the column template to use (without extension).")
+	_ = cmd.RegisterFlagCompletionFunc("template", completions.TemplateNames)
 	cmd.Flags().StringSliceVarP(&o.Columns, "columns", "c", nil, "Comma-separated list of column headers to display (subset of the template's columns, case-insensitive).")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "", "Output format. One of: json, yaml, csv. If empty, prints the standard table.")
+	_ = cmd.RegisterFlagCompletionFunc("output", cobra.FixedCompletions([]string{"json", "yaml", "csv"}, cobra.ShellCompDirectiveNoFileComp))
 	cmd.Flags().StringVar(&o.SortColumn, "sort-by", "", "Column header to sort rows by (case-insensitive). Numeric strings sort numerically.")
 	cmd.Flags().StringArrayVar(&o.FilterExprs, "filter", nil, "Filter rows by column values: COL=val, COL!=val, COL~regex, COL!~regex (repeatable, ANDed).")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use.")
+	_ = cmd.RegisterFlagCompletionFunc("context", completions.KubeContexts)
 	cmd.Flags().BoolVar(&o.EnableCustomTable, "ctable", false, "Enable custom table output with borders.")
 	return cmd
 }

--- a/pkg/cmd/template/create.go
+++ b/pkg/cmd/template/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/models"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
@@ -74,6 +75,7 @@ Edit the generated file to add more columns.`,
 
 	createCMD.Flags().StringP("name", "n", "", "Name for the new template (without extension)")
 	createCMD.Flags().StringP("resource", "r", "", "Resource type to create the template for (e.g. pod, deployment)")
+	_ = createCMD.RegisterFlagCompletionFunc("resource", completions.ResourceTypes)
 	createCMD.MarkFlagRequired("resource")
 	createCMD.MarkFlagRequired("name")
 

--- a/pkg/cmd/template/edit.go
+++ b/pkg/cmd/template/edit.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -101,7 +102,9 @@ template name.`,
 	}
 
 	editCMD.Flags().StringP("resource", "r", "", "Resource type to edit the template for (e.g. pod, deployment)")
+	_ = editCMD.RegisterFlagCompletionFunc("resource", completions.ResourceTypes)
 	editCMD.Flags().StringP("template", "t", "default", "Name of the template to edit (without extension)")
+	_ = editCMD.RegisterFlagCompletionFunc("template", completions.TemplateNames)
 	editCMD.MarkFlagRequired("resource")
 
 	return editCMD

--- a/pkg/cmd/template/list.go
+++ b/pkg/cmd/template/list.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -58,6 +59,7 @@ directory. Duplicates (same name, different extension) are shown once.`,
 	}
 
 	templateCMD.Flags().StringP("resource", "r", "", "Resource type to list templates for (e.g. pod, deployment)")
+	_ = templateCMD.RegisterFlagCompletionFunc("resource", completions.ResourceTypes)
 	templateCMD.MarkFlagRequired("resource")
 
 	return templateCMD

--- a/pkg/cmd/template/scaffold.go
+++ b/pkg/cmd/template/scaffold.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,8 @@ This is intended as a "first draft" — cwide's 'init' auto-generates a more
 complete template by inspecting the CRD schema.`,
 		Example: `  # Pipe to a template file
   kubectl cwide template scaffold pod > ~/.kubectl-cwide/templates/pod--v1/starter.yaml`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completions.ResourceTypes,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			body := scaffoldFor(args[0])
 			_, err := fmt.Fprint(cmd.OutOrStdout(), body)

--- a/pkg/cmd/tree/tree.go
+++ b/pkg/cmd/tree/tree.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubectl-cwide/pkg/clients"
+	"github.com/kubectl-cwide/pkg/cmd/completions"
 	"github.com/kubectl-cwide/pkg/models"
 	"github.com/kubectl-cwide/pkg/utils"
 	"github.com/spf13/cobra"
@@ -82,6 +83,13 @@ Binding types:
   # Mixed: rules file + extra inline relation
   kubectl cwide tree deployment/nginx -f deploy-stack.yaml --related=hpa:ownerRef`,
 		Args: cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			// Only complete when the user hasn't typed the "/" separator yet.
+			if strings.Contains(toComplete, "/") {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return completions.ResourceTypes(cmd, args, toComplete)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Complete(cmd, args); err != nil {
 				return err
@@ -97,6 +105,7 @@ Binding types:
 	cmd.Flags().StringArrayVar(&o.RelatedFlags, "related", nil, "Inline relationship: <resource>:<bindType>[:<parent>] (repeatable)")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "Namespace scope for this request")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The name of the kubeconfig context to use")
+	_ = cmd.RegisterFlagCompletionFunc("context", completions.KubeContexts)
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "List across all namespaces")
 	cmd.Flags().IntVar(&o.MaxDepth, "max-depth", 0, "Maximum tree depth to render; 0 means unbounded. Cycles are always broken with a (cycle) marker.")
 	cmd.Flags().BoolVar(&o.Reverse, "reverse", false, "Show ancestors (via ownerReferences) instead of descendants.")


### PR DESCRIPTION
## Summary

Extends the static completion scripts (already shipped in v0.8.0) with dynamic, context-aware completions so pressing TAB actually surfaces the values the user was about to type.

New `pkg/cmd/completions` package with four reusable ValidArgsFunction/completion callbacks:

- **`ResourceTypes`** — resource names + short names (from cluster discovery) + user-defined aliases. Wired into \`get\`, \`tree\`, \`template scaffold\`, and the \`-r\` flag on template create/edit/list.
- **`AliasNames`** — configured alias names. Wired into \`alias delete\`.
- **`TemplateNames`** — template basenames discovered from the template root. Wired into the \`--template\` / \`-t\` flag on \`get\` and \`template edit\`.
- **`KubeContexts`** — context names from the loading kubeconfig. Wired into \`--context\` on \`get\` and \`tree\`.
- Also: \`-o\` on \`get\` gets fixed completions for \`json\`/\`yaml\`/\`csv\`.

All discovery-backed completions are best-effort — if the cluster is unreachable, they return no suggestions rather than a visible error.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — new unit test for filterPrefix passes
- [ ] Manual: source \`kubectl cwide completion bash\` in a shell and verify:
  - \`kubectl cwide get <TAB>\` lists resource types + aliases
  - \`kubectl cwide alias delete <TAB>\` lists configured aliases
  - \`kubectl cwide get pods -t <TAB>\` lists templates for pods
  - \`kubectl cwide get pods --context=<TAB>\` lists contexts